### PR TITLE
feat(Extra-Protection):  basic rate limiting middleware and image size check

### DIFF
--- a/packages/api/app/app.js
+++ b/packages/api/app/app.js
@@ -6,11 +6,23 @@ import corsMiddleware from "./middlewares/cors.js";
 import tokenRouter from "./routes/token.js";
 import utilityRouter from "./routes/utility.js";
 import scoutRouter from "./routes/scout.js";
+import rateLimit from "express-rate-limit";
 
 const app = express();
 const server = createServer(app);
 
 const PORT = process.env.PORT || 3000;
+
+//Basic rate limiting middleware (e.g., 1000 requests per 15 minutes per IP)
+const apiLimiter = rateLimit({
+  windowMs: 5 * 60 * 1000, // 5 minutes
+  max: 300, // Limit each IP to 300 requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, please try again later." },
+});
+
+app.use(apiLimiter);
 
 app.use(corsMiddleware);
 app.use(express.json());

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,6 +14,7 @@
     "discord-interactions": "^4.3.0",
     "dotenv": "^16.4.5",
     "express": "^5.0.1",
+    "express-rate-limit": "^7.5.0",
     "mongodb": "^6.9.0",
     "mongoose": "^8.7.3",
     "node-fetch": "^3.3.2",


### PR DESCRIPTION
- basic rate limit 300 requests X 5 mins
- Check image size before sending back, limit 512KB