### PR TITLE
feat(invasions): Better estimated invasion times for new invasions

### DIFF
--- a/packages/api/app/routes/invasionHelpers.js
+++ b/packages/api/app/routes/invasionHelpers.js
@@ -57,13 +57,13 @@ function updateInvasionDataCache(invasion, district) {
 }
 
 function calculateInvasionRates(dataPoints, startTimestamp) {
-  if (dataPoints.length < 2) {
+  if (dataPoints.length < 4) {
     return { currentRate: null, avgRate: null, isReliable: false };
   }
-  // Current rate: last 3 data points for responsiveness
-  const recentPoints = dataPoints.slice(-3);
+  // Current rate: last 5 data points for responsiveness
+  const recentPoints = dataPoints.slice(-5);
   let currentRate = null;
-  if (recentPoints.length >= 2) {
+  if (recentPoints.length >= 4) {
     const first = recentPoints[0];
     const last = recentPoints[recentPoints.length - 1];
     const timeElapsed = last.timestamp - first.timestamp;
@@ -84,7 +84,7 @@ function calculateInvasionRates(dataPoints, startTimestamp) {
   }
   // Rate is reliable if we have enough data points and consistent rates
   const isReliable =
-    dataPoints.length >= 3 &&
+    dataPoints.length >= 5 &&
     currentRate &&
     avgRate &&
     Math.abs(currentRate - avgRate) / avgRate < 0.5; // Within 50% of each other
@@ -141,11 +141,11 @@ function calculateEstimatedEndTime(invasion, district) {
   if (!cacheEntry) return null;
   const maxDuration = cacheEntry.maxDuration;
   const absoluteEndTime = invasion.startTimestamp + maxDuration;
-  // If very early in invasion (<5% progress or <3 data points), use baseline defeat rate
+  // If very early in invasion (<5% progress or <5 data points), use baseline defeat rate
   const progressPercent = current / total;
   if (
     progressPercent < 0.05 ||
-    (cacheEntry.dataPoints && cacheEntry.dataPoints.length < 3)
+    (cacheEntry.dataPoints && cacheEntry.dataPoints.length < 5)
   ) {
     const remaining = total - current;
     const baselineSeconds = Math.ceil(remaining / BASELINE_COGS_PER_SEC);

--- a/packages/api/app/routes/invasionHelpers.js
+++ b/packages/api/app/routes/invasionHelpers.js
@@ -116,6 +116,10 @@ function estimateEndTimeByProgress(
   return null;
 }
 
+// Baseline defeat rate for fallback (cogs per minute)
+const BASELINE_COGS_PER_MIN = 80;
+const BASELINE_COGS_PER_SEC = BASELINE_COGS_PER_MIN / 60;
+
 function calculateEstimatedEndTime(invasion, district) {
   const now = invasion.asOf || Math.floor(Date.now() / 1000);
   if (!invasion.progress || !invasion.progress.includes("/")) return null;
@@ -130,14 +134,24 @@ function calculateEstimatedEndTime(invasion, district) {
   // Handle mega invasions - always use fixed 3-hour duration
   if (total === MEGA_INVASION_COGS && invasion.startTimestamp) {
     const endTime = invasion.startTimestamp + MEGA_INVASION_DURATION;
-    return Math.floor(endTime);
+    return Math.max(now, Math.floor(endTime));
   }
   // Update cache with new data point
   const cacheEntry = updateInvasionDataCache(invasion, district);
   if (!cacheEntry) return null;
   const maxDuration = cacheEntry.maxDuration;
   const absoluteEndTime = invasion.startTimestamp + maxDuration;
-  // Strategy 1: Use actual defeat rate if reliable - which means we have at least 3 data points
+  // If very early in invasion (<5% progress or <3 data points), use baseline defeat rate
+  const progressPercent = current / total;
+  if (
+    progressPercent < 0.05 ||
+    (cacheEntry.dataPoints && cacheEntry.dataPoints.length < 3)
+  ) {
+    const remaining = total - current;
+    const baselineSeconds = Math.ceil(remaining / BASELINE_COGS_PER_SEC);
+    return Math.max(now, now + baselineSeconds);
+  }
+  // Strategy 1: Use actual defeat rate if reliable
   if (cacheEntry.isRateReliable) {
     const endTime = estimateEndTimeByRate(
       now,
@@ -146,7 +160,7 @@ function calculateEstimatedEndTime(invasion, district) {
       cacheEntry.currentRate,
       absoluteEndTime
     );
-    if (endTime !== null) return Math.floor(endTime);
+    if (endTime !== null) return Math.max(now, Math.floor(endTime));
   }
   // Strategy 2: Use average rate if available but not fully reliable
   if (cacheEntry.avgRate > 0) {
@@ -157,9 +171,9 @@ function calculateEstimatedEndTime(invasion, district) {
       cacheEntry.avgRate,
       absoluteEndTime
     );
-    if (endTime !== null) return Math.floor(endTime);
+    if (endTime !== null) return Math.max(now, Math.floor(endTime));
   }
-  // Strategy 3: Early invasion - use progress scaling
+  // Strategy 3: Use progress scaling
   const progressEndTime = estimateEndTimeByProgress(
     now,
     current,
@@ -167,9 +181,22 @@ function calculateEstimatedEndTime(invasion, district) {
     invasion.startTimestamp,
     maxDuration
   );
-  if (progressEndTime !== null) return Math.floor(progressEndTime);
-  // Strategy 4: Fallback to maximum duration
-  return Math.floor(absoluteEndTime);
+  // If the progress-based estimate is in the past or too short, fallback to baseline defeat rate
+  if (progressEndTime !== null) {
+    if (
+      (progressEndTime < now || progressEndTime - now < 60) &&
+      current < total
+    ) {
+      const remaining = total - current;
+      const baselineSeconds = Math.ceil(remaining / BASELINE_COGS_PER_SEC);
+      return Math.max(now, now + baselineSeconds);
+    }
+    return Math.max(now, Math.floor(progressEndTime));
+  }
+  // Fallback: baseline defeat rate
+  const remaining = total - current;
+  const baselineSeconds = Math.ceil(remaining / BASELINE_COGS_PER_SEC);
+  return Math.max(now, now + baselineSeconds);
 }
 
 async function getInvasions() {
@@ -224,4 +251,5 @@ export {
   getMaxInvasionDuration,
   MEGA_INVASION_COGS,
   NORMAL_INVASION_MAX_RATE,
+  calculateEstimatedEndTime,
 };

--- a/packages/api/app/routes/utility.js
+++ b/packages/api/app/routes/utility.js
@@ -94,10 +94,10 @@ router.post("/get-garden", async (req, res) => {
 
 let cachedInvasions = null;
 let lastFetchTime = 0;
-const INVASION_CACHE_MS = 60 * 1000;
+const INVASION_CACHE_MS = 30 * 1000; // 30 seconds
 
 router.get("/get-invasions", async (req, res) => {
-  res.set("Cache-Control", "public, max-age=60");
+  res.set("Cache-Control", "public, max-age=30");
   if (cachedInvasions && Date.now() - lastFetchTime < INVASION_CACHE_MS) {
     return res.json(cachedInvasions);
   }

--- a/packages/webapp/app/components/Home/tabs/InvasionCard.tsx
+++ b/packages/webapp/app/components/Home/tabs/InvasionCard.tsx
@@ -37,7 +37,7 @@ const InvasionCard: React.FC<InvasionCardProps> = ({
 
   return (
     <motion.div
-      key={`${invasion.asOf}-${invasion.district}-${invasion.cog}`}
+      key={`${invasion.district}-${invasion.cog}-${invasion.startTimestamp}`}
       initial={{ y: -40, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       exit={{ y: -40, opacity: 0 }}

--- a/packages/webapp/app/components/Home/tabs/InvasionsTab.tsx
+++ b/packages/webapp/app/components/Home/tabs/InvasionsTab.tsx
@@ -77,7 +77,7 @@ const InvasionsTab: React.FC<TabProps> = ({ toon }) => {
               );
               return (
                 <InvasionCard
-                  key={`${invasion.asOf}-${invasion.district}-${invasion.cog}`}
+                  key={`${invasion.district}-${invasion.cog}-${invasion.startTimestamp}`}
                   invasion={invasion}
                   percent={percent}
                   isRelevant={isRelevant}

--- a/packages/webapp/app/context/InvasionContext.tsx
+++ b/packages/webapp/app/context/InvasionContext.tsx
@@ -59,7 +59,7 @@ interface TTRInvasionResponse {
 }
 
 // Intervals in milliseconds
-const LIVE_DATA_INTERVAL = 60000; // 60 seconds for live data
+const LIVE_DATA_INTERVAL = 30000; // 30 seconds for live data
 
 const InvasionContext = createContext<InvasionContextType>({
   invasions: [],
@@ -71,25 +71,23 @@ export const InvasionProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [invasions, setInvasions] = useState<InvasionData[]>([]);
   const [loading, setLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState<number>(0);
   const prevInvasions = useRef<InvasionData[]>([]);
 
   useEffect(() => {
     let interval: NodeJS.Timeout | null = null;
     let isFirstFetch = true;
+    let nextInterval = LIVE_DATA_INTERVAL;
 
     const fetchInvasions = async () => {
       try {
         if (isFirstFetch) setLoading(true);
 
-        // Always use live endpoint now
         const endpoint = `${API_LINK}/utility/get-invasions`;
-
         const response = await fetch(endpoint, {
           cache: "no-store",
         });
-
         if (!response.ok) throw new Error("Network response was not ok");
-
         const data = (await response.json()) as TTRInvasionResponse;
         if (data.error) return;
 
@@ -103,12 +101,20 @@ export const InvasionProvider: React.FC<{ children: React.ReactNode }> = ({
             estimatedEndTime: invasion.estimatedEndTime,
           })
         );
-        // Set the invasions state
-        setInvasions(transformed);
+        if (data.lastUpdated !== lastUpdated) {
+          setInvasions(transformed);
+          setLastUpdated(data.lastUpdated);
+        }
 
         prevInvasions.current = transformed;
+
+        // Dynamically adjust next poll interval based on TTR's lastUpdated
+        const nowSec = Math.floor(Date.now() / 1000);
+        const ttrDelay = Math.max(10, 65 - (nowSec - data.lastUpdated)); // poll at least every 10s, but try to sync with TTR (which updates about every 60-65s)
+        nextInterval = ttrDelay * 1000;
+        if (interval) clearInterval(interval);
+        interval = setInterval(fetchInvasions, nextInterval);
       } catch (e) {
-        // Optionally handle error
         console.error("Error fetching invasions:", e);
       } finally {
         if (isFirstFetch) setLoading(false);
@@ -116,11 +122,7 @@ export const InvasionProvider: React.FC<{ children: React.ReactNode }> = ({
       }
     };
 
-    // Initial fetch
     fetchInvasions();
-
-    // Set interval for live data
-    interval = setInterval(fetchInvasions, LIVE_DATA_INTERVAL);
 
     return () => {
       if (interval) clearInterval(interval);


### PR DESCRIPTION
- Improved invasion end time estimation logic:
  - Added baseline defeat rate (80 cogs/min) when insufficient data points are available.
    - Should fix issue of incorrect estimations when invasions are starting
  - Increased required data points for rate-based estimation from 3 to 5.
 
- Optimized backend caching and frontend polling:
  - Set backend invasion cache and HTTP cache-control to 30 seconds.
  - Frontend now dynamically adjusts polling interval based on TTR's lastUpdated value to avoid unnecessary requests.
  - Frontend only updates invasion state if lastUpdated changes, preventing redundant UI updates and janky animations.