### PR TITLE
style: update relevant invasion border and invasion list scrollbar to…

### DIFF
--- a/packages/webapp/app/components/Home/tabs/InvasionCard.tsx
+++ b/packages/webapp/app/components/Home/tabs/InvasionCard.tsx
@@ -43,9 +43,9 @@ const InvasionCard: React.FC<InvasionCardProps> = ({
       exit={{ y: -40, opacity: 0 }}
       transition={{ type: "spring", stiffness: 300, damping: 30 }}
       layout
-      className={`p-4 border-2 rounded-xl bg-white dark:bg-gray-1100 shadow-md space-y-3 transition-all duration-300 hover:shadow-lg ${
+      className={`p-4 border-4 rounded-xl bg-white dark:bg-gray-1100 shadow-md space-y-3 transition-all duration-300 ${
         isRelevant
-          ? "border-yellow-400 ring-2 ring-yellow-200 dark:ring-yellow-600"
+          ? "border-yellow-400"
           : "border-gray-200 dark:border-gray-600"
       }`}
     >
@@ -67,7 +67,7 @@ const InvasionCard: React.FC<InvasionCardProps> = ({
           <h3 className="font-bold text-xl md:text-2xl text-pink-700 dark:text-pink-300 flex items-center gap-2 mt-0">
             {sanitizeCogName(invasion.cog)}
             {isRelevant && (
-              <span className="ml-2 px-2 py-0.5 rounded bg-yellow-200 text-yellow-900 text-xs font-semibold">
+              <span className="ml-2 px-3 py-1 rounded bg-yellow-200 text-yellow-900 text-base font-bold">
                 Relevant
               </span>
             )}

--- a/packages/webapp/app/components/Home/tabs/InvasionsTab.tsx
+++ b/packages/webapp/app/components/Home/tabs/InvasionsTab.tsx
@@ -58,7 +58,7 @@ const InvasionsTab: React.FC<TabProps> = ({ toon }) => {
 
   return (
     <AnimatedTabContent>
-      <div className="flex flex-col gap-4 max-h-[60vh] overflow-y-auto pr-2">
+      <div className="flex flex-col gap-4 max-h-[60vh] overflow-y-auto pr-2 fish-scrollbar">
         {loading ? (
           <div className="flex items-center justify-center py-8">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-pink-500"></div>


### PR DESCRIPTION
Updated Styles for invasion list and relevant invasion card
closes #93 
- Made text for relevant invasion bigger
- Updated yellow border to not show white space
- Updated invasion list scrollbar to match fish list scrollbar

### Screenshots:
Light:
<img width="791" alt="Screenshot 2025-06-14 135255" src="https://github.com/user-attachments/assets/3c678a74-9fb2-4a7b-805a-fafb4c377004" />

Dark:
<img width="827" alt="Screenshot 2025-06-14 135242" src="https://github.com/user-attachments/assets/4ee2b401-ada3-4b7e-bf92-26529db8f96e" />
