### PR TITLE
feat(gag-damage): Added gag damage tooltip

### DIFF
--- a/packages/webapp/app/components/Home/tabs/GagsTab.tsx
+++ b/packages/webapp/app/components/Home/tabs/GagsTab.tsx
@@ -1,12 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 import { TabProps } from "./components/TabComponent";
 import AnimatedTabContent from "../../animations/AnimatedTab";
 import "/styles/tabs.css";
 import ExpContainer from "./components/ExpContainer";
 import Image from "next/image";
 import { gagImages, GagTrack } from "@/assets/gags/index";
+import { getGagTooltipData, GagTrackKey } from "@/app/utils/gagDamage";
+import GagTooltip from "./components/GagTooltip";
 
 const GagsTab: React.FC<TabProps> = ({ toon }) => {
+  const [hoveredGag, setHoveredGag] = useState<string | null>(null);
   const tracks = Object.keys(toon.data.data.gags);
 
   const bgMap = {
@@ -31,8 +34,8 @@ const GagsTab: React.FC<TabProps> = ({ toon }) => {
 
   return (
     <AnimatedTabContent>
-      <div className="container mx-auto">
-        {tracks.map((track) => {
+      <div className="container mx-auto py-8">
+        {tracks.map((track, index) => {
           const trackData = toon.data.data.gags[track];
           const trackBg = bgMap[track as keyof typeof bgMap];
           const trackText = textMap[track as keyof typeof textMap];
@@ -42,7 +45,9 @@ const GagsTab: React.FC<TabProps> = ({ toon }) => {
           return (
             <div
               key={track}
-              className={`flex items-center ${trackBg} rounded-3xl py-2 space-x-1 shadow-lg relative overflow-hidden inline-flex max-w-max pr-4`}
+              className={`flex items-center ${trackBg} rounded-3xl py-2 space-x-1 shadow-lg relative overflow-visible inline-flex max-w-max pr-4 ${
+                index === 0 ? "mt-4" : ""
+              }`}
             >
               <div className="hidden sm:flex lg:hidden xl:flex flex-col px-2">
                 <h3
@@ -57,65 +62,75 @@ const GagsTab: React.FC<TabProps> = ({ toon }) => {
               </div>
               <div className="grid grid-cols-7 gap-2 pl-2 sm:pl-0 lg:pl-2 xl:pl-0">
                 {[...Array(7)].map((_, gagIndex) => {
-                  const gagImage =
-                    gagImages[track.toLowerCase() as GagTrack]?.[gagIndex];
+                  const gagImage = gagImages[track.toLowerCase() as GagTrack]?.[gagIndex];
                   const isImageVisible = trackData && gagIndex + 1 <= maxLevel;
                   const gagLevel = gagIndex + 1;
-                  const organicLevel = trackData?.organic?.level ?? 0;
-                  const isOrganic = gagLevel <= organicLevel;
-                  
+                  const tooltipData = getGagTooltipData(track as GagTrackKey, gagLevel, maxLevel, trackData);
+                  const isRightmostGag = gagIndex === 6 || gagIndex + 1 === maxLevel;
+                  const gagKey = `${track}-${gagLevel}`;
+                  const isHovered = hoveredGag === gagKey;
+
                   return (
                     <div
                       key={`${track}-${gagIndex}`}
                       className={`w-14 h-10 md:w-16 md:h-12 2xl:w-20 2xl:h-16 rounded-3xl flex items-center justify-center relative shadow-lg ${
                         isImageVisible ? "bg-gagblue" : ""
                       }`}
+                      onMouseEnter={() => setHoveredGag(gagKey)}
+                      onMouseLeave={() => setHoveredGag(null)}
                     >
-                      {/* unowned slot */}
                       {!isImageVisible && (
-                        <div
-                          className={`absolute inset-0 bg-black opacity-15 rounded-3xl`}
-                        ></div>
-                      )}
-                      {/* gag slot */}
-                      {isImageVisible && gagImage && (
-                        <>
-                          <Image
-                            src={gagImage}
-                            alt={`${track} gag ${gagLevel}`}
-                            width={48}
-                            height={48}
-                            className="w-8 xl:w-10 2xl:w-12 object-contain"
-                          />
-                          {/* organic gag indicator */}
-                          {isOrganic && (
-                            <Image
-                              src="/organic-gag.webp"
-                              alt="Organic"
-                              width={18}
-                              height={18}
-                              className="absolute -top-0.5 -right-0.5 w-4 h-4 md:w-5 md:h-5 xl:w-6 xl:h-6 2xl:w-7 2xl:h-7 pointer-events-none"
-                            />
-                          )}
-                        </>
+                        <div className="absolute inset-0 bg-black opacity-15 rounded-3xl pointer-events-none" />
                       )}
 
-                      {/* gag border styling */}
+                      {isImageVisible && gagImage && (
+                        <Image
+                          src={gagImage}
+                          alt={`${track} gag ${gagLevel}`}
+                          width={48}
+                          height={48}
+                          className="w-8 xl:w-10 2xl:w-12 object-contain pointer-events-none"
+                        />
+                      )}
+
+                      {isImageVisible && tooltipData?.isOrganic && (
+                        <Image
+                          src="/organic-gag.webp"
+                          alt="Organic"
+                          width={18}
+                          height={18}
+                          className="absolute -top-0.5 -right-0.5 w-4 h-4 md:w-5 md:h-5 xl:w-6 xl:h-6 2xl:w-7 2xl:h-7 pointer-events-none"
+                        />
+                      )}
+
+                      {isImageVisible && tooltipData && (
+                        <GagTooltip
+                          track={track}
+                          gagLevel={gagLevel}
+                          damageInfo={tooltipData.damageInfo}
+                          baseDamageInfo={tooltipData.baseDamageInfo}
+                          accuracyInfo={tooltipData.accuracyInfo}
+                          isOrganic={tooltipData.isOrganic}
+                          isHovered={isHovered}
+                          isRightmost={isRightmostGag}
+                        />
+                      )}
+
                       {isImageVisible && (
                         <div
-                          className={`absolute inset-0 border-2 border-solid rounded-3xl shadow-md`}
+                          className={`absolute inset-0 border-2 border-solid rounded-3xl shadow-md pointer-events-none`}
                           style={{
                             borderColor: `rgba(0, 0, 0, 0.1)`,
                           }}
                         >
                           <div
-                            className={`absolute inset-0 border-2 border-b-8 opacity-5 border-solid rounded-3xl`}
+                            className={`absolute inset-0 border-2 border-b-8 opacity-5 border-solid rounded-3xl pointer-events-none`}
                             style={{
                               borderColor: `white`,
                             }}
                           ></div>
                           <div
-                            className={`absolute inset-0 border-4 border-t-8 opacity-5 border-solid rounded-3xl`}
+                            className={`absolute inset-0 border-4 border-t-8 opacity-5 border-solid rounded-3xl pointer-events-none`}
                             style={{
                               borderColor: `white`,
                             }}
@@ -126,7 +141,7 @@ const GagsTab: React.FC<TabProps> = ({ toon }) => {
                   );
                 })}
                 <div
-                  className={`absolute inset-0 border-4 border-solid rounded-3xl`}
+                  className={`absolute inset-0 border-4 border-solid rounded-3xl pointer-events-none`}
                   style={{
                     borderColor: `rgba(0, 0, 0, 0.2)`,
                   }}

--- a/packages/webapp/app/components/Home/tabs/GagsTab.tsx
+++ b/packages/webapp/app/components/Home/tabs/GagsTab.tsx
@@ -62,11 +62,18 @@ const GagsTab: React.FC<TabProps> = ({ toon }) => {
               </div>
               <div className="grid grid-cols-7 gap-2 pl-2 sm:pl-0 lg:pl-2 xl:pl-0">
                 {[...Array(7)].map((_, gagIndex) => {
-                  const gagImage = gagImages[track.toLowerCase() as GagTrack]?.[gagIndex];
+                  const gagImage =
+                    gagImages[track.toLowerCase() as GagTrack]?.[gagIndex];
                   const isImageVisible = trackData && gagIndex + 1 <= maxLevel;
                   const gagLevel = gagIndex + 1;
-                  const tooltipData = getGagTooltipData(track as GagTrackKey, gagLevel, maxLevel, trackData);
-                  const isRightmostGag = gagIndex === 6 || gagIndex + 1 === maxLevel;
+                  const tooltipData = getGagTooltipData(
+                    track as GagTrackKey,
+                    gagLevel,
+                    maxLevel,
+                    trackData
+                  );
+                  const isRightmostGag =
+                    gagIndex === 6 || gagIndex + 1 === maxLevel;
                   const gagKey = `${track}-${gagLevel}`;
                   const isHovered = hoveredGag === gagKey;
 
@@ -90,16 +97,6 @@ const GagsTab: React.FC<TabProps> = ({ toon }) => {
                           width={48}
                           height={48}
                           className="w-8 xl:w-10 2xl:w-12 object-contain pointer-events-none"
-                        />
-                      )}
-
-                      {isImageVisible && tooltipData?.isOrganic && (
-                        <Image
-                          src="/organic-gag.webp"
-                          alt="Organic"
-                          width={18}
-                          height={18}
-                          className="absolute -top-0.5 -right-0.5 w-4 h-4 md:w-5 md:h-5 xl:w-6 xl:h-6 2xl:w-7 2xl:h-7 pointer-events-none"
                         />
                       )}
 
@@ -136,6 +133,16 @@ const GagsTab: React.FC<TabProps> = ({ toon }) => {
                             }}
                           ></div>
                         </div>
+                      )}
+
+                      {isImageVisible && tooltipData?.isOrganic && (
+                        <Image
+                          src="/organic-gag.webp"
+                          alt="Organic"
+                          width={18}
+                          height={18}
+                          className="absolute -top-0.5 -right-0.5 w-4 h-4 md:w-5 md:h-5 xl:w-6 xl:h-6 2xl:w-7 2xl:h-7 pointer-events-none"
+                        />
                       )}
                     </div>
                   );

--- a/packages/webapp/app/components/Home/tabs/components/GagTooltip.tsx
+++ b/packages/webapp/app/components/Home/tabs/components/GagTooltip.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { DamageInfo, AccuracyInfo, LURE_ROUNDS } from "@/app/utils/gagDamage";
+
+export type GagTooltipProps = {
+  track: string;
+  gagLevel: number;
+  damageInfo: DamageInfo | null;
+  baseDamageInfo: DamageInfo | null;
+  accuracyInfo: AccuracyInfo | null;
+  isOrganic: boolean;
+  isHovered: boolean;
+  isRightmost: boolean;
+};
+
+const GagTooltip: React.FC<GagTooltipProps> = ({
+  track,
+  gagLevel,
+  damageInfo,
+  baseDamageInfo,
+  accuracyInfo,
+  isOrganic,
+  isHovered,
+  isRightmost,
+}) => {
+  const tooltipPositionClass = isRightmost ? 'right-0' : 'left-1/2 -translate-x-1/2';
+
+  return (
+    <div
+      className={`absolute bottom-full ${tooltipPositionClass} mb-2 bg-gray-900 text-white text-sm font-bold rounded px-3 py-2 whitespace-nowrap`}
+      style={{
+        opacity: isHovered ? 1 : 0,
+        visibility: isHovered ? 'visible' : 'hidden',
+        zIndex: 10000,
+        pointerEvents: 'none',
+        transition: 'opacity 0.2s, visibility 0.2s'
+      }}
+    >
+      {track === "Lure" ? (
+        <div className="flex flex-col gap-1">
+          <div>
+            ROUNDS LURED: {isOrganic ? LURE_ROUNDS[gagLevel - 1] + 1 : LURE_ROUNDS[gagLevel - 1]}
+            {isOrganic && (
+              <> ({LURE_ROUNDS[gagLevel - 1]} + 1)</>
+            )}
+          </div>
+          {accuracyInfo && (
+            <div className="text-xs font-normal">
+              Accuracy: {accuracyInfo.organic ?? accuracyInfo.base}%
+              {accuracyInfo.organic && accuracyInfo.organic !== accuracyInfo.base && (
+                <> ({accuracyInfo.base}% + {accuracyInfo.organic - accuracyInfo.base}%)</>
+              )}
+            </div>
+          )}
+        </div>
+      ) : damageInfo ? (
+        <div className="flex flex-col gap-1">
+          <div>
+            {track === "Toon-Up" ? "HEALING: " : "DAMAGE: "}
+            {isOrganic && baseDamageInfo ? (
+              <>{damageInfo.value} ({baseDamageInfo.value} + {damageInfo.value - baseDamageInfo.value})</>
+            ) : (
+              <>{damageInfo.value}</>
+            )}
+          </div>
+          {accuracyInfo && (
+            <div className="text-xs font-normal">
+              Accuracy: {accuracyInfo.organic ?? accuracyInfo.base}%
+              {accuracyInfo.organic && accuracyInfo.organic !== accuracyInfo.base && (
+                <> ({accuracyInfo.base}% + {accuracyInfo.organic - accuracyInfo.base}%)</>
+              )}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div>Level {gagLevel} {track}</div>
+      )}
+      <div
+        className={`absolute top-full ${isRightmost ? 'right-4' : 'left-1/2 -translate-x-1/2'}`}
+        style={{
+          width: 0,
+          height: 0,
+          borderLeft: '8px solid transparent',
+          borderRight: '8px solid transparent',
+          borderTop: '8px solid rgb(17, 24, 39)'
+        }}
+      ></div>
+    </div>
+  );
+};
+
+export default GagTooltip;

--- a/packages/webapp/app/components/Home/tabs/components/GagTooltip.tsx
+++ b/packages/webapp/app/components/Home/tabs/components/GagTooltip.tsx
@@ -38,10 +38,7 @@ const GagTooltip: React.FC<GagTooltipProps> = ({
       {track === "Lure" ? (
         <div className="flex flex-col gap-1">
           <div>
-            ROUNDS LURED: {isOrganic ? LURE_ROUNDS[gagLevel - 1] + 1 : LURE_ROUNDS[gagLevel - 1]}
-            {isOrganic && (
-              <> ({LURE_ROUNDS[gagLevel - 1]} + 1)</>
-            )}
+            ROUNDS LURED: {LURE_ROUNDS[gagLevel - 1]}
           </div>
           {accuracyInfo && (
             <div className="text-xs font-normal">

--- a/packages/webapp/app/utils/gagDamage.ts
+++ b/packages/webapp/app/utils/gagDamage.ts
@@ -1,0 +1,234 @@
+export type GagTrackKey =
+  | "Toon-Up"
+  | "Trap"
+  | "Lure"
+  | "Sound"
+  | "Throw"
+  | "Squirt"
+  | "Drop";
+
+/**
+ * XP thresholds to unlock each gag level per track
+ */
+export const XP_THRESHOLDS: Record<GagTrackKey, number[]> = {
+  "Toon-Up": [0, 20, 200, 800, 2000, 6000, 10000],
+  Trap: [0, 20, 100, 500, 2000, 6000, 10000],
+  Lure: [0, 20, 100, 800, 2000, 6000, 10000],
+  Sound: [0, 20, 200, 800, 2000, 6000, 10000],
+  Throw: [0, 10, 50, 400, 2000, 6000, 10000],
+  Squirt: [0, 10, 50, 400, 2000, 6000, 10000],
+  Drop: [0, 20, 100, 500, 2000, 6000, 10000],
+};
+
+const throwDamageRanges: Array<{ start: number; max: number }> = [
+  { start: 4, max: 6 }, // Cupcake
+  { start: 8, max: 10 }, // Fruit Pie Slice
+  { start: 14, max: 17 }, // Cream Pie Slice
+  { start: 24, max: 27 }, // Whole Fruit Pie
+  { start: 36, max: 40 }, // Whole Cream Pie
+  { start: 48, max: 100 }, // Birthday Cake
+  { start: 120, max: 120 }, // Wedding Cake
+];
+
+const squirtDamageRanges: Array<{ start: number; max: number }> = [
+  { start: 3, max: 4 }, // Squirting Flower
+  { start: 6, max: 8 }, // Glass of Water
+  { start: 10, max: 12 }, // Squirt Gun
+  { start: 18, max: 21 }, // Seltzer Bottle
+  { start: 27, max: 30 }, // Fire Hose
+  { start: 36, max: 80 }, // Storm Cloud
+  { start: 105, max: 105 }, // Geyser
+];
+
+const soundDamageRanges: Array<{ start: number; max: number }> = [
+  { start: 3, max: 4 }, // Bike Horn
+  { start: 5, max: 7 }, // Whistle
+  { start: 9, max: 11 }, // Bugle
+  { start: 14, max: 16 }, // Aoogah
+  { start: 19, max: 21 }, // Elephant Trunk
+  { start: 25, max: 50 }, // Fog Horn
+  { start: 90, max: 90 }, // Opera Singer
+];
+
+const dropDamageRanges: Array<{ start: number; max: number }> = [
+  { start: 10, max: 10 }, // Flower Pot
+  { start: 18, max: 18 }, // Sandbag
+  { start: 30, max: 30 }, // Anvil
+  { start: 45, max: 45 }, // Big Weight
+  { start: 60, max: 70 }, // Safe
+  { start: 85, max: 170 }, // Grand Piano
+  { start: 180, max: 180 }, // Toontanic
+];
+
+const trapDamageRanges: Array<{ start: number; max: number }> = [
+  { start: 10, max: 12 }, // Banana Peel
+  { start: 18, max: 20 }, // Rake
+  { start: 30, max: 35 }, // Marbles
+  { start: 45, max: 50 }, // Quicksand
+  { start: 75, max: 85 }, // Trapdoor
+  { start: 90, max: 180 }, // TNT
+  { start: 200, max: 200 }, // Railroad
+];
+
+const toonUpHealingRanges: Array<{ start: number; max: number }> = [
+  { start: 8, max: 10 }, // Feather
+  { start: 15, max: 18 }, // Megaphone
+  { start: 27, max: 30 }, // Lipstick
+  { start: 40, max: 45 }, // Bamboo Cane
+  { start: 50, max: 60 }, // Pixie Dust
+  { start: 75, max: 105 }, // Juggling Cubes
+  { start: 210, max: 210 }, // High Dive
+];
+
+// Source: https://toontownrewritten.wiki/Lure
+export const LURE_ROUNDS: number[] = [2, 2, 3, 3, 4, 4, 8];
+
+// Source: https://toontownrewritten.wiki/Accuracy
+export const BASE_ACCURACY: Record<GagTrackKey, number | number[]> = {
+  "Toon-Up": [70, 70, 70, 70, 70, 70, 95],
+  Trap: 0,
+  Lure: [60, 55, 70, 65, 80, 75, 90],
+  Sound: 95,
+  Throw: 75,
+  Squirt: 95,
+  Drop: 50,
+};
+
+export type DamageInfo = {
+  value: number;
+  start: number;
+  max: number;
+};
+
+export type AccuracyInfo = {
+  base: number;
+  organic?: number;
+};
+
+export type GagTrackData = {
+  gag: { level: number };
+  experience: { current: number; next: number };
+  organic?: { level: number };
+};
+
+export type GagTooltipData = {
+  damageInfo: DamageInfo | null;
+  baseDamageInfo: DamageInfo | null;
+  accuracyInfo: AccuracyInfo | null;
+  isOrganic: boolean;
+};
+
+const DAMAGE_RANGES: Record<string, Array<{ start: number; max: number }>> = {
+  "Toon-Up": toonUpHealingRanges,
+  Throw: throwDamageRanges,
+  Squirt: squirtDamageRanges,
+  Sound: soundDamageRanges,
+  Drop: dropDamageRanges,
+  Trap: trapDamageRanges,
+};
+
+export function getGagDamage(
+  track: GagTrackKey,
+  level: number,
+  currXP: number,
+  nextXP: number | null | undefined,
+  organic?: boolean,
+): DamageInfo | null {
+  if (track === "Lure") return null;
+
+  const ranges = DAMAGE_RANGES[track];
+  if (!ranges) return null;
+
+  if (level < 1 || level > 7) return null;
+
+  const idx = level - 1;
+  const range = ranges[idx];
+  if (!range) return null;
+
+  const trackThresholds = XP_THRESHOLDS[track];
+  const y = trackThresholds[idx] ?? 0;
+  const x = nextXP ?? trackThresholds[Math.min(idx + 1, trackThresholds.length - 1)];
+
+  const o = range.start;
+  const m = range.max;
+
+  let organicMultiplier = 1.1;
+  if (track === "Toon-Up") {
+    organicMultiplier = 1.20;
+  } else if (track === "Squirt" || track === "Drop") {
+    organicMultiplier = 1.15;
+  }
+
+  const deltaXP = Math.max(0, x - y);
+  const earned = Math.max(0, currXP - y);
+  if (deltaXP === 0) {
+    const base = organic ? Math.ceil(Math.round(m * organicMultiplier * 100) / 100) : m;
+    return { value: base, start: o, max: m };
+  }
+
+  const xpPerPoint = deltaXP / (m - o + 1);
+  const unrounded = o + earned / xpPerPoint;
+  let dmg = Math.floor(unrounded);
+  dmg = Math.max(o, Math.min(dmg, m));
+  if (organic) {
+    const organicValue = dmg * organicMultiplier;
+    dmg = Math.ceil(Math.round(organicValue * 100) / 100);
+  }
+  return { value: dmg, start: o, max: m };
+}
+
+export function getGagAccuracy(
+  track: GagTrackKey,
+  level: number,
+  organic?: boolean,
+): AccuracyInfo | null {
+  if (track === "Trap") return null;
+
+  if (level < 1 || level > 7) return null;
+
+  const accuracyData = BASE_ACCURACY[track];
+  const baseAccuracy = Array.isArray(accuracyData)
+    ? accuracyData[level - 1]
+    : accuracyData;
+
+  if (track === "Lure" && organic) {
+    const organicBonus = level === 7 ? 5 : 10;
+    return { base: baseAccuracy, organic: baseAccuracy + organicBonus };
+  }
+
+  return { base: baseAccuracy };
+}
+
+export function getGagTooltipData(
+  track: GagTrackKey,
+  gagLevel: number,
+  maxLevel: number,
+  trackData: GagTrackData | null | undefined
+): GagTooltipData | null {
+  if (!trackData || gagLevel > maxLevel) return null;
+
+  const organicLevel = trackData.organic?.level ?? 0;
+  const isOrganic = gagLevel <= organicLevel;
+  const exp = trackData.experience;
+  const trackThresholds = XP_THRESHOLDS[track];
+
+  let damageInfo: DamageInfo | null;
+  let baseDamageInfo: DamageInfo | null = null;
+
+  if (gagLevel === maxLevel && exp) {
+    damageInfo = getGagDamage(track, gagLevel, exp.current, exp.next, isOrganic);
+    if (isOrganic) {
+      baseDamageInfo = getGagDamage(track, gagLevel, exp.current, exp.next, false);
+    }
+  } else {
+    const nextLevelXP = trackThresholds[gagLevel] ?? 10000;
+    damageInfo = getGagDamage(track, gagLevel, nextLevelXP - 1, nextLevelXP, isOrganic);
+    if (isOrganic) {
+      baseDamageInfo = getGagDamage(track, gagLevel, nextLevelXP - 1, nextLevelXP, false);
+    }
+  }
+
+  const accuracyInfo = getGagAccuracy(track, gagLevel, isOrganic);
+
+  return { damageInfo, baseDamageInfo, accuracyInfo, isOrganic };
+}


### PR DESCRIPTION
- Added tooltip displaying gag damage based on the track XP
- closes #96 
```
  Damage Calculation Formula:
  damage = floor(minDamage + (earnedXP / xpPerPoint))
  Where:
  - xpPerPoint = (nextLevelXP - currentLevelXP) / (maxDamage - minDamage + 1)
  - earnedXP = currentXP - currentLevelXP
  - Damage scales linearly from min to max as you earn XP toward the next gag level

  Organic Bonuses:
  - Toon-Up: 20% bonus healing
  - Squirt & Drop: 15% bonus damage
  - Other tracks: 10% bonus damage
  - Lure: +1 round (+10% accuracy for levels 1-6, +5% for level 7)
 ```
### Screenshots:
<img width="2286" height="1461" alt="image" src="https://github.com/user-attachments/assets/a075b3a3-abf2-40a6-9ca7-a58cb6d11c56" />
<img width="2325" height="1488" alt="image" src="https://github.com/user-attachments/assets/ca33d58c-785a-4d93-ba4c-2601124a7c80" />
<img width="2355" height="1491" alt="image" src="https://github.com/user-attachments/assets/0a6900bd-5f0c-40fa-a738-e46d648db432" />
