### PR TITLE
fix(invasion): timer for non skelecog invasions was broken

### DIFF
--- a/packages/api/app/routes/invasionHelpers.js
+++ b/packages/api/app/routes/invasionHelpers.js
@@ -129,12 +129,23 @@ function calculateEstimatedEndTime(invasion, district) {
   if (!invasion.progress || !invasion.progress.includes("/")) return null;
   const [current, total] = invasion.progress.split("/").map(Number);
   
-  // Check for skelecog invasions first, before validating current
+  // Skelecog mega invasion: always use fixed 3-hour duration
   if (isSkelecogInvasion(invasion) && invasion.startTimestamp && total) {
     const endTime = invasion.startTimestamp + MEGA_INVASION_DURATION;
     return Math.max(now, Math.floor(endTime));
   }
-  
+
+  //  mega invasion: 0/1000000 progress, estimatedEndTime null, use 3-hour duration
+  if (
+    total === MEGA_INVASION_COGS &&
+    invasion.startTimestamp &&
+    current === 0 &&
+    (!('estimatedEndTime' in invasion) || invasion.estimatedEndTime == null)
+  ) {
+    const endTime = invasion.startTimestamp + MEGA_INVASION_DURATION;
+    return Math.max(now, Math.floor(endTime));
+  }
+
   if (!current || !total) return null;
   const cacheKey = getInvasionCacheKey(invasion, district);
   // Clean up cache if invasion is complete
@@ -142,7 +153,7 @@ function calculateEstimatedEndTime(invasion, district) {
     invasionDataCache.delete(cacheKey);
     return now;
   }
-  // Handle mega invasions - always use fixed 3-hour duration
+  // Handle other mega invasions (with progress): always use fixed 3-hour duration
   if (total === MEGA_INVASION_COGS && invasion.startTimestamp) {
     const endTime = invasion.startTimestamp + MEGA_INVASION_DURATION;
     return Math.max(now, Math.floor(endTime));
@@ -230,6 +241,10 @@ async function getInvasions() {
           invasion,
           district
         );
+        // Add isMegaInvasion flag (true for 1,000,000 cogs, not skelecog)
+        const isSkelecog = isSkelecogInvasion(invasion);
+        const [current, total] = (invasion.progress || "0/0").split("/").map(Number);
+        invasion.isMegaInvasion = isSkelecog || total === MEGA_INVASION_COGS;
       }
     }
     // Clean up cache for invasions that no longer exist in the latest API response

--- a/packages/webapp/app/components/Home/tabs/InvasionCard.tsx
+++ b/packages/webapp/app/components/Home/tabs/InvasionCard.tsx
@@ -25,23 +25,19 @@ const InvasionCard: React.FC<InvasionCardProps> = ({
       : null,
   );
 
-  // Check if this is a skelecog invasion
-  const isSkelecog =
-    invasion.cog && invasion.cog.toLowerCase().includes("skelecog");
+  // Use backend-provided isMegaInvasion flag
+  const isMegaInvasion = invasion.isMegaInvasion === true;
 
-  // For skelecog invasions, calculate progress based on time elapsed since no progress is provided
-  const skelecogProgress =
-    isSkelecog && invasion.startTimestamp
-      ? Math.min(
-          100,
-          Math.max(
-            0,
-            ((Math.floor(Date.now() / 1000) - invasion.startTimestamp) /
-              10800) *
-              100,
-          ),
-        )
-      : 0;
+  // For skelecog and mega invasions, calculate progress based on time elapsed
+  const timeBasedProgress = (invasion.startTimestamp && typeof estimatedEndTime === "number")
+    ? Math.min(
+        100,
+        Math.max(
+          0,
+          ((Math.floor(Date.now() / 1000) - invasion.startTimestamp) / 10800) * 100,
+        ),
+      )
+    : 0;
 
   useEffect(() => {
     if (typeof estimatedEndTime !== "number") return;
@@ -84,6 +80,11 @@ const InvasionCard: React.FC<InvasionCardProps> = ({
           })()}
           <h3 className="font-bold text-xl md:text-2xl text-pink-700 dark:text-pink-300 flex items-center gap-2 mt-0">
             {sanitizeCogName(invasion.cog)}
+            {isMegaInvasion && (
+              <span className="ml-2 px-3 py-1 rounded bg-purple-200 text-purple-900 text-base font-bold border border-purple-400">
+                Mega
+              </span>
+            )}
             {isRelevant && (
               <span className="ml-2 px-3 py-1 rounded bg-yellow-200 text-yellow-900 text-base font-bold">
                 Relevant
@@ -93,7 +94,7 @@ const InvasionCard: React.FC<InvasionCardProps> = ({
         </div>
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2 text-blue-900 dark:text-blue-300">
-            <FaGlobe className="inline-block mr-1" />
+            <FaGlobe size={18} />
             <span className="font-semibold">{invasion.district}</span>
           </div>
         </div>
@@ -101,22 +102,22 @@ const InvasionCard: React.FC<InvasionCardProps> = ({
       {/* Progress and bar first, then Est. Time Left at bottom right, Start Time at bottom left */}
       <div className="flex flex-col items-center w-full gap-2 mt-2">
         <div className="text-center text-base font-medium mb-1">
-          {isSkelecog
-            ? `Progress: ${skelecogProgress.toFixed(0)}%`
+          {isMegaInvasion
+            ? `Progress: ${timeBasedProgress.toFixed(0)}%`
             : `Progress: ${invasion.progress} (${percent.toFixed(0)}%)`}
         </div>
         <div className="w-full max-w-xs h-4 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden mb-1">
           <motion.div
             className="h-full bg-pink-600 dark:bg-pink-400 transition-all duration-500 rounded-full"
             initial={{ width: 0 }}
-            animate={{ width: `${isSkelecog ? skelecogProgress : percent}%` }}
+            animate={{ width: `${isMegaInvasion ? timeBasedProgress : percent}%` }}
             transition={{ duration: 0.8, ease: "easeOut" }}
           />
         </div>
       </div>
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-gray-700 dark:text-gray-200 text-sm mt-2">
         <div className="flex items-center gap-1">
-          <FaClock className="inline-block" />
+          <FaClock size={16} />
           <span>
             Start: {new Date(invasion.startTimestamp * 1000).toLocaleString()}
           </span>

--- a/packages/webapp/app/context/InvasionContext.tsx
+++ b/packages/webapp/app/context/InvasionContext.tsx
@@ -40,6 +40,7 @@ interface InvasionData {
   startTimestamp: number;
   district: string;
   estimatedEndTime?: number | null;
+  isMegaInvasion?: boolean;
 }
 
 // TypeScript interface for the API response
@@ -53,6 +54,7 @@ interface TTRInvasionResponse {
       startTimestamp: number;
       estimatedEndTime?: number | null;
       rate?: number;
+      isMegaInvasion?: boolean;
     };
   };
   lastUpdated: number;
@@ -99,6 +101,7 @@ export const InvasionProvider: React.FC<{ children: React.ReactNode }> = ({
             startTimestamp: invasion.startTimestamp,
             district,
             estimatedEndTime: invasion.estimatedEndTime,
+            isMegaInvasion: invasion.isMegaInvasion,
           }),
         );
         if (data.lastUpdated !== lastUpdated) {


### PR DESCRIPTION
- Mega invasions that are not skelecog invasions were not estimate time to end properly.
- Added a chip in the UI for mega invasions

Before:
<img width="1864" height="685" alt="image" src="https://github.com/user-attachments/assets/708b716b-497f-40c2-96e1-219264645e38" />


After:
<img width="1873" height="580" alt="image" src="https://github.com/user-attachments/assets/a44710c0-3916-4ddc-ae9f-f04b19f96a5d" />
