### PR TITLE
feat(taskline-updater): created update script and GHA

### DIFF
--- a/.github/workflows/taskline-update.yml
+++ b/.github/workflows/taskline-update.yml
@@ -1,0 +1,38 @@
+name: Taskline Update
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  taskline-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Refresh tasklines
+        run: node scripts/tasklines/update_tasklines.js --refresh --report-path .github/taskline-update-report.md
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: 'Update taskline data from wiki'
+          title: 'Update taskline data from wiki'
+          body-path: '.github/taskline-update-report.md'
+          branch: 'automation/taskline-update'
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -430,3 +430,5 @@ wrapper/
 .vs
 /test
 ngrok.yml
+.github/taskline-update-report.md
+packages/webapp/data/tasklines/metadata.json

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "devDependencies": {
+    "slugify": "1.6.6"
+  },
   "workspaces": [
     "packages/api",
     "packages/bot",

--- a/scripts/tasklines/lib/config.js
+++ b/scripts/tasklines/lib/config.js
@@ -1,0 +1,103 @@
+const path = require('path');
+
+/**
+ * @typedef {Object} TasklineConfig
+ * @property {string} file
+ * @property {string} playground
+ * @property {string} category
+ * @property {string} taskCategory
+ */
+
+/**
+ * @typedef {Object} CogDisguisePageConfig
+ * @property {string} file
+ * @property {string} playground
+ * @property {string} title
+ */
+
+const OUTPUT_DIR = path.resolve(__dirname, '..', '..', '..', 'packages', 'webapp', 'data', 'tasklines');
+const METADATA_PATH = path.join(OUTPUT_DIR, 'metadata.json');
+
+/** @type {TasklineConfig[]} */
+const PLAYGROUND_CONFIGS = [
+  {
+    file: 'toontown_central.json',
+    playground: 'Toontown Central',
+    category: 'Toontown Central ToonTasks',
+    taskCategory: 'playground',
+  },
+  {
+    file: 'donalds_dock.json',
+    playground: "Donald's Dock",
+    category: "Donald's Dock ToonTasks",
+    taskCategory: 'playground',
+  },
+  {
+    file: 'daisy_gardens.json',
+    playground: 'Daisy Gardens',
+    category: 'Daisy Gardens ToonTasks',
+    taskCategory: 'playground',
+  },
+  {
+    file: 'minnies_melodyland.json',
+    playground: "Minnie's Melodyland",
+    category: "Minnie's Melodyland ToonTasks",
+    taskCategory: 'playground',
+  },
+  {
+    file: 'the_brrrgh.json',
+    playground: 'The Brrrgh',
+    category: 'The Brrrgh ToonTasks',
+    taskCategory: 'playground',
+  },
+  {
+    file: 'donalds_dreamland.json',
+    playground: "Donald's Dreamland",
+    category: "Donald's Dreamland ToonTasks",
+    taskCategory: 'playground',
+  },
+];
+
+/** @type {TasklineConfig[]} */
+const SPECIAL_CONFIGS = [
+  {
+    file: 'sellbot_task_force.json',
+    playground: 'Sellbot Task Force',
+    category: 'Sellbot Task Force ToonTasks',
+    taskCategory: 'task_force',
+  },
+];
+
+// Single-page cog disguises (all tasks on one wiki page)
+/** @type {CogDisguisePageConfig[]} */
+const COG_DISGUISE_PAGES = [
+  {
+    file: 'lawbot_cog_disguise.json',
+    playground: 'Lawbot Cog Disguise',
+    title: 'Lawbot_Cog_Disguise',
+  },
+  {
+    file: 'bossbot_cog_disguise.json',
+    playground: 'Bossbot Cog Disguise',
+    title: 'Bossbot_Cog_Disguise',
+  },
+];
+
+// Cashbot is handled separately because its tasks are spread across multiple pages
+// in the Donald's Dreamland ToonTasks category (8 wiki-documented parts).
+// NOTE: 4 arm parts from random tasks are intentionally excluded - they have no
+// dedicated wiki pages and will likely change in the upcoming task revamp.
+const CASHBOT_DISGUISE_CONFIGS = {
+  file: 'cashbot_cog_disguise.json',
+  playground: 'Cashbot Cog Disguise',
+  titleSubstring: 'Cashbot Cog Disguise',
+};
+
+module.exports = {
+  OUTPUT_DIR,
+  METADATA_PATH,
+  PLAYGROUND_CONFIGS,
+  SPECIAL_CONFIGS,
+  COG_DISGUISE_PAGES,
+  CASHBOT_DISGUISE_CONFIGS,
+};

--- a/scripts/tasklines/lib/metadata.js
+++ b/scripts/tasklines/lib/metadata.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+
+function readMetadata(metadataPath) {
+  if (!fs.existsSync(metadataPath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+  } catch (error) {
+    return null;
+  }
+}
+
+function writeMetadata(metadataPath, outputs, failures, getDiffSummary) {
+  const summary = getDiffSummary(outputs);
+  const hasChanges =
+    summary.tasklinesAdded > 0 ||
+    summary.tasklinesRemoved > 0 ||
+    summary.tasklinesChanged > 0 ||
+    summary.stepsAdded > 0 ||
+    summary.stepsRemoved > 0 ||
+    summary.stepsChanged > 0;
+
+  if (!hasChanges) {
+    return;
+  }
+
+  const now = new Date().toISOString();
+  const existing = readMetadata(metadataPath);
+  const metadata = {
+    lastChecked: now,
+    lastUpdated: hasChanges ? now : (existing && existing.lastUpdated) || now,
+    generator: {
+      script: 'scripts/tasklines/update_tasklines.js',
+      mode: hasChanges ? 'refresh' : 'check',
+    },
+    summary: {
+      tasklines: {
+        added: summary.tasklinesAdded,
+        removed: summary.tasklinesRemoved,
+        changed: summary.tasklinesChanged,
+      },
+      steps: {
+        added: summary.stepsAdded,
+        removed: summary.stepsRemoved,
+        changed: summary.stepsChanged,
+      },
+    },
+    parsingFailures: failures.length,
+  };
+
+  fs.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+}
+
+module.exports = {
+  readMetadata,
+  writeMetadata,
+};

--- a/scripts/tasklines/lib/parser.js
+++ b/scripts/tasklines/lib/parser.js
@@ -1,0 +1,285 @@
+const slugifyLib = require('slugify');
+
+function slugify(value) {
+  const normalized = value.replace(/-/g, ' ');
+  return slugifyLib(normalized, {
+    lower: true,
+    replacement: '_',
+    remove: /['’+]/g,
+  });
+}
+
+function stripWikiMarkup(text) {
+  return text
+    .replace(/\{\{[^}]*\}\}/g, '')
+    .replace(/<\s*script[^>]*>[\s\S]*?<\s*\/\s*script\s*>/gi, '')
+    .replace(/<\s*style[^>]*>[\s\S]*?<\s*\/\s*style\s*>/gi, '')
+    .replace(/<\s*ref[^>]*>[\s\S]*?<\s*\/\s*ref\s*>/gi, '')
+    .replace(/<\s*ref[^>]*\/\s*>/gi, '')
+    .replace(/<\s*\/?\s*[a-z][^>]*>/gi, '')
+    .replace(/\[\[(?:[^\]|]*\|)?([^\]]+)\]\]/g, '$1')
+    .replace(/''+/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function validateParsedText(text) {
+  if (text.includes('{{') || text.includes('}}') || text.includes('[[') || text.includes(']]')) {
+    throw new Error('Unexpected wiki markup after sanitization');
+  }
+}
+
+
+/**
+ * @param {string} wikitext
+ * @returns {string}
+ */
+function extractSection(wikitext) {
+  const lines = wikitext.split('\n');
+  const sectionLines = [];
+  let inSection = false;
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    const isHeading = /^==[^=].*==$/.test(line);
+    if (!inSection) {
+      if (/^==\s*ToonTasks?\s*==$/i.test(line)) {
+        inSection = true;
+      }
+      continue;
+    }
+    if (isHeading) {
+      break;
+    }
+    sectionLines.push(rawLine);
+  }
+  return sectionLines.join('\n');
+}
+
+/**
+ * @param {string} rawText
+ * @param {{ keepParenthetical: boolean }} options
+ * @returns {{ objective: string, building?: string, location?: string }}
+ */
+function parseObjectiveDetails(rawText, { keepParenthetical }) {
+  const cleaned = stripWikiMarkup(rawText);
+  validateParsedText(cleaned);
+  // Nested parentheticals are not fully supported; this captures the outermost group.
+  const match = cleaned.match(/^(.*?)(?:\(([^)]*)\))?$/);
+  const objectiveBase = match ? match[1].trim() : cleaned;
+  const parenText = match && match[2] ? match[2].trim() : '';
+
+  let objective = objectiveBase;
+  if (keepParenthetical && parenText) {
+    objective = `${objectiveBase} (${parenText})`;
+  }
+
+  let building;
+  let location;
+  if (parenText) {
+    const parts = parenText.split(',').map(part => part.trim()).filter(Boolean);
+    if (parts.length === 1) {
+      if (parts[0].toLowerCase() !== 'anywhere') {
+        location = parts[0];
+      } else {
+        location = 'Anywhere';
+      }
+    } else if (parts.length >= 2) {
+      building = parts[0];
+      location = parts[parts.length - 1];
+    }
+  }
+
+  if (parenText.toLowerCase() === 'anywhere') {
+    location = 'Anywhere';
+  }
+
+  return {
+    objective,
+    building,
+    location,
+  };
+}
+
+/**
+ * Splits a ToonTask section into subsections if they exist (===NPC Name===).
+ * Returns array of {subsectionName, content} objects.
+ * If no subsections exist, returns single entry with null subsectionName.
+ */
+function splitSubsections(sectionText) {
+  const lines = sectionText.split('\n');
+  const subsections = [];
+  let currentSubsection = null;
+  let currentLines = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const subsectionMatch = trimmed.match(/^===\s*(.+?)\s*===$/);
+
+    if (subsectionMatch) {
+      if (currentSubsection !== null || currentLines.length > 0) {
+        subsections.push({
+          subsectionName: currentSubsection,
+          content: currentLines.join('\n'),
+        });
+      }
+      currentSubsection = subsectionMatch[1];
+      currentLines = [];
+    } else {
+      currentLines.push(line);
+    }
+  }
+
+  if (currentSubsection !== null || currentLines.length > 0) {
+    subsections.push({
+      subsectionName: currentSubsection,
+      content: currentLines.join('\n'),
+    });
+  }
+
+  return subsections.length > 0 ? subsections : [{ subsectionName: null, content: sectionText }];
+}
+
+/**
+ * @param {string} sectionText
+ * @returns {Array<{ order: number, objective: string, npc?: string, building?: string, location?: string }>}
+ */
+function parseToonTaskSteps(sectionText) {
+  const lines = sectionText.split('\n');
+  const rawSteps = [];
+  let current = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('#')) {
+      continue;
+    }
+    if (trimmed.startsWith('#*')) {
+      if (current) {
+        current.subitems.push(trimmed.replace(/^#\*+/, '').trim());
+      }
+      continue;
+    }
+    if (current) {
+      rawSteps.push(current);
+    }
+    current = {
+      text: trimmed.replace(/^#+/, '').trim(),
+      subitems: [],
+    };
+  }
+  if (current) {
+    rawSteps.push(current);
+  }
+
+  return rawSteps.map((step, index) => {
+    if (step.subitems.length > 0 || /^One of the following/i.test(step.text)) {
+      const subObjectives = step.subitems.map(item =>
+        parseObjectiveDetails(item, { keepParenthetical: false }).objective
+      );
+      const objective = `One of the following: ${subObjectives.join(' ')}`.trim();
+      const firstSub = step.subitems[0] || '';
+      const parsedFirst = parseObjectiveDetails(firstSub, { keepParenthetical: false });
+      const npc =
+        subObjectives[0] && !/^Return to/i.test(subObjectives[0])
+          ? `One of the following: ${subObjectives[0]}`
+          : undefined;
+      return {
+        order: index + 1,
+        objective,
+        npc,
+        building: parsedFirst.building,
+        location: parsedFirst.location,
+      };
+    }
+
+    const details = parseObjectiveDetails(step.text, { keepParenthetical: false });
+    return {
+      order: index + 1,
+      objective: details.objective,
+      building: details.building,
+      location: details.location,
+    };
+  });
+}
+
+/**
+ * @param {string} sectionText
+ * @returns {Array<{ name: string, steps: Array<{ order: number, objective: string, building?: string, location?: string }> }>}
+ */
+function parseCogDisguiseSteps(sectionText) {
+  const lines = sectionText.split('\n');
+  const tasklines = [];
+  let currentName = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith(';')) {
+      currentName = stripWikiMarkup(trimmed.replace(/^;+/, '').trim());
+      continue;
+    }
+    if (trimmed.startsWith('*') && currentName) {
+      const details = parseObjectiveDetails(trimmed.replace(/^\*+/, '').trim(), {
+        keepParenthetical: true,
+      });
+      tasklines.push({
+        name: currentName,
+        steps: [
+          {
+            order: 1,
+            objective: details.objective,
+            building: details.building,
+            location: details.location,
+          },
+        ],
+      });
+    }
+  }
+  return tasklines;
+}
+
+/**
+ * @param {string} titlePart
+ * @returns {string}
+ */
+function normalizeTasklineName(titlePart) {
+  const cleaned = titlePart.replace(/_/g, ' ').trim();
+  if (/^Gag pouch$/i.test(cleaned)) {
+    return 'Upgraded gag pouch';
+  }
+  if (/^Jellybean pouch$/i.test(cleaned)) {
+    return 'Upgraded jellybean pouch';
+  }
+  if (/^ToonTask capacity$/i.test(cleaned)) {
+    return 'Increased ToonTask capacity';
+  }
+  const laffMatch = cleaned.match(/^\+?\d+ laff boost/i);
+  if (laffMatch) {
+    return laffMatch[0].replace(/^\+/, '+');
+  }
+  return cleaned.replace(/\s*\([^)]*\)\s*$/, '').trim();
+}
+
+/**
+ * @param {string} title
+ * @returns {string}
+ */
+function buildWikiUrl(title) {
+  const encoded = title
+    .split('/')
+    .map(segment =>
+      encodeURIComponent(segment.replace(/ /g, '_')).replace(/'/g, '%27')
+    )
+    .join('/');
+  return `https://toontownrewritten.wiki/${encoded}`;
+}
+
+module.exports = {
+  slugify,
+  extractSection,
+  splitSubsections,
+  parseToonTaskSteps,
+  parseCogDisguiseSteps,
+  normalizeTasklineName,
+  buildWikiUrl,
+};

--- a/scripts/tasklines/lib/report.js
+++ b/scripts/tasklines/lib/report.js
@@ -1,0 +1,214 @@
+const fs = require('fs');
+const path = require('path');
+const { isDeepStrictEqual } = require('util');
+
+const MAX_STEP_CHANGES_IN_REPORT = 5;
+
+/**
+ * @param {Array<any>} existing
+ * @param {Array<any>} updated
+ * @param {Function} getTasklineKey
+ * @returns {{ added: Array<{name: string, id: string}>, removed: Array<{name: string, id: string}>, changed: Array<{name: string, id: string}>, changedDetails: Array<any>, stepsAdded: number, stepsRemoved: number, stepsChanged: number }}
+ */
+function diffTasklines(existing, updated, getTasklineKey) {
+  const existingMap = new Map(existing.map(item => [getTasklineKey(item), item]));
+  const updatedMap = new Map(updated.map(item => [getTasklineKey(item), item]));
+
+  const added = [];
+  const removed = [];
+  const changed = [];
+  const changedDetails = [];
+  let stepsAdded = 0;
+  let stepsRemoved = 0;
+  let stepsChanged = 0;
+
+  for (const [key, item] of updatedMap) {
+    if (!existingMap.has(key)) {
+      added.push({ name: item.name, id: item.id });
+      stepsAdded += item.steps.length;
+      continue;
+    }
+    const existingItem = existingMap.get(key);
+    if (!isDeepStrictEqual(existingItem, item)) {
+      changed.push({ name: item.name, id: item.id });
+      const oldSteps = existingItem.steps || [];
+      const newSteps = item.steps || [];
+      const detail = {
+        name: item.name,
+        id: item.id,
+        stepsAdded: 0,
+        stepsRemoved: 0,
+        stepsChanged: 0,
+        stepChanges: [],
+      };
+      if (newSteps.length > oldSteps.length) {
+        const delta = newSteps.length - oldSteps.length;
+        stepsAdded += delta;
+        detail.stepsAdded += delta;
+      } else if (oldSteps.length > newSteps.length) {
+        const delta = oldSteps.length - newSteps.length;
+        stepsRemoved += delta;
+        detail.stepsRemoved += delta;
+      }
+      const minLen = Math.min(oldSteps.length, newSteps.length);
+      for (let i = 0; i < minLen; i++) {
+        if (!isDeepStrictEqual(oldSteps[i], newSteps[i])) {
+          stepsChanged += 1;
+          detail.stepsChanged += 1;
+          if (detail.stepChanges.length < MAX_STEP_CHANGES_IN_REPORT) {
+            detail.stepChanges.push({
+              order: oldSteps[i].order,
+              before: oldSteps[i].objective,
+              after: newSteps[i].objective,
+            });
+          }
+        }
+      }
+      changedDetails.push(detail);
+    }
+  }
+
+  for (const [key, item] of existingMap) {
+    if (!updatedMap.has(key)) {
+      removed.push({ name: item.name, id: item.id });
+      stepsRemoved += item.steps.length;
+    }
+  }
+
+  return {
+    added,
+    removed,
+    changed,
+    changedDetails,
+    stepsAdded,
+    stepsRemoved,
+    stepsChanged,
+  };
+}
+
+/**
+ * @param {Array<{ diff: any }>} outputs
+ * @returns {{ tasklinesAdded: number, tasklinesRemoved: number, tasklinesChanged: number, stepsAdded: number, stepsRemoved: number, stepsChanged: number }}
+ */
+function getDiffSummary(outputs) {
+  return outputs.reduce(
+    (acc, output) => {
+      acc.tasklinesAdded += output.diff.added.length;
+      acc.tasklinesRemoved += output.diff.removed.length;
+      acc.tasklinesChanged += output.diff.changed.length;
+      acc.stepsAdded += output.diff.stepsAdded;
+      acc.stepsRemoved += output.diff.stepsRemoved;
+      acc.stepsChanged += output.diff.stepsChanged;
+      return acc;
+    },
+    {
+      tasklinesAdded: 0,
+      tasklinesRemoved: 0,
+      tasklinesChanged: 0,
+      stepsAdded: 0,
+      stepsRemoved: 0,
+      stepsChanged: 0,
+    }
+  );
+}
+
+/**
+ * @param {string|null} reportPath
+ * @param {Array<any>} outputs
+ * @param {Array<{title: string, reason: string}>} failures
+ */
+function writeReport(reportPath, outputs, failures) {
+  if (!reportPath) {
+    return;
+  }
+
+  const timestamp = new Date().toISOString();
+  const summary = getDiffSummary(outputs);
+
+  const lines = [];
+  lines.push('# Taskline Update Report');
+  lines.push('');
+  lines.push(`Generated: ${timestamp}`);
+  lines.push('');
+  lines.push('## Summary');
+  lines.push(`- Tasklines added: ${summary.tasklinesAdded}`);
+  lines.push(`- Tasklines removed: ${summary.tasklinesRemoved}`);
+  lines.push(`- Tasklines changed: ${summary.tasklinesChanged}`);
+  lines.push(`- Steps added: ${summary.stepsAdded}`);
+  lines.push(`- Steps removed: ${summary.stepsRemoved}`);
+  lines.push(`- Steps changed: ${summary.stepsChanged}`);
+  lines.push('');
+
+  if (summary.tasklinesRemoved > 0 || summary.stepsRemoved > 0) {
+    lines.push('## Warning');
+    lines.push(
+      '- A decrease in taskline or step counts can be expected during major content changes.'
+    );
+    lines.push(
+      '- Review removals to ensure the wiki data and progression logic still align with ToonScout.'
+    );
+    lines.push('');
+  }
+
+  lines.push('## Details');
+  lines.push('<details>');
+  lines.push('<summary>Per-file changes</summary>');
+  lines.push('');
+  for (const output of outputs) {
+    const fileName = path.basename(output.filePath);
+    const diff = output.diff;
+    lines.push(`- ${fileName}`);
+    lines.push(`  - tasklines: +${diff.added.length} / -${diff.removed.length} / ~${diff.changed.length}`);
+    lines.push(`  - steps: +${diff.stepsAdded} / -${diff.stepsRemoved} / ~${diff.stepsChanged}`);
+    if (diff.added.length) {
+      lines.push(
+        `  - added: ${diff.added.map(item => `${item.name} (${item.id})`).join(', ')}`
+      );
+    }
+    if (diff.removed.length) {
+      lines.push(
+        `  - removed: ${diff.removed.map(item => `${item.name} (${item.id})`).join(', ')}`
+      );
+    }
+    if (diff.changed.length) {
+      lines.push(
+        `  - changed: ${diff.changed.map(item => `${item.name} (${item.id})`).join(', ')}`
+      );
+    }
+    if (diff.changedDetails.length) {
+      lines.push(`  <details>`);
+      lines.push(`  <summary>Taskline change details</summary>`);
+      lines.push('');
+      diff.changedDetails.forEach(detail => {
+        lines.push(
+          `  - ${detail.name} (${detail.id}): steps +${detail.stepsAdded} / -${detail.stepsRemoved} / ~${detail.stepsChanged}`
+        );
+        detail.stepChanges.forEach(change => {
+          lines.push(
+            `    - step ${change.order}: "${change.before}" -> "${change.after}"`
+          );
+        });
+      });
+      lines.push(`  </details>`);
+      lines.push('');
+    }
+  }
+  lines.push('</details>');
+  lines.push('');
+
+  if (failures.length) {
+    lines.push('## Parsing Issues');
+    failures.forEach(failure => {
+      lines.push(`- ${failure.title} (${failure.reason})`);
+    });
+    lines.push('');
+  }
+
+  fs.writeFileSync(reportPath, `${lines.join('\n')}\n`);
+}
+
+module.exports = {
+  diffTasklines,
+  getDiffSummary,
+  writeReport,
+};

--- a/scripts/tasklines/lib/wiki.js
+++ b/scripts/tasklines/lib/wiki.js
@@ -1,0 +1,79 @@
+const API_BASE = 'https://toontownrewritten.wiki/api.php';
+const API_TIMEOUT_MS = 30000;
+
+/**
+ * @typedef {Object} WikiPageContent
+ * @property {string} wikitext
+ * @property {string|null} timestamp
+ */
+
+async function fetchJson(url) {
+  const response = await fetch(url, { signal: AbortSignal.timeout(API_TIMEOUT_MS) });
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status} ${response.statusText} (${url})`);
+  }
+  return response.json();
+}
+
+async function fetchCategoryMembers(category) {
+  const members = [];
+  let cmcontinue = null;
+  do {
+    const params = new URLSearchParams({
+      action: 'query',
+      list: 'categorymembers',
+      cmtitle: `Category:${category.replace(/ /g, '_')}`,
+      cmlimit: 'max',
+      format: 'json',
+    });
+    if (cmcontinue) {
+      params.append('cmcontinue', cmcontinue);
+    }
+    const url = `${API_BASE}?${params.toString()}`;
+    const data = await fetchJson(url);
+    members.push(...data.query.categorymembers);
+    cmcontinue = data.continue ? data.continue.cmcontinue : null;
+  } while (cmcontinue);
+  return members;
+}
+
+async function fetchPageContent(title) {
+  const params = new URLSearchParams({
+    action: 'query',
+    prop: 'revisions',
+    titles: title,
+    rvprop: 'timestamp|content',
+    rvslots: 'main',
+    redirects: '1',
+    format: 'json',
+  });
+  const url = `${API_BASE}?${params.toString()}`;
+  const data = await fetchJson(url);
+  const pages = data.query && data.query.pages ? data.query.pages : {};
+  const page = pages[Object.keys(pages)[0]];
+  if (!page || !page.revisions || !page.revisions.length) {
+    throw new Error('Missing page revisions');
+  }
+  const revision = page.revisions[0];
+  const slot = revision.slots ? revision.slots.main : null;
+  const wikitext =
+    slot && typeof slot['*'] === 'string'
+      ? slot['*']
+      : slot && typeof slot.content === 'string'
+        ? slot.content
+        : typeof revision['*'] === 'string'
+          ? revision['*']
+          : revision.content || '';
+  if (!wikitext) {
+    throw new Error('Missing wikitext content');
+  }
+  return {
+    wikitext,
+    timestamp: revision.timestamp || null,
+  };
+}
+
+module.exports = {
+  fetchCategoryMembers,
+  fetchPageContent,
+};

--- a/scripts/tasklines/run_update_tests.js
+++ b/scripts/tasklines/run_update_tests.js
@@ -1,0 +1,200 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { execSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const DATA_DIR = path.join(ROOT, 'packages', 'webapp', 'data', 'tasklines');
+const EXCLUDED_FILES = new Set(['metadata.json', 'sellbot_cog_disguise.json']);
+const REPORT_PATH = path.join(ROOT, '.github', 'taskline-update-report.md');
+const RESULTS_PATH = path.join(__dirname, 'UPDATE_TASKLINES_TEST_RESULTS.md');
+
+function run(command) {
+  execSync(command, { stdio: 'inherit', cwd: ROOT, timeout: 120000 });
+}
+
+function listAllJsonFiles() {
+  return fs
+    .readdirSync(DATA_DIR)
+    .filter(file => file.endsWith('.json'));
+}
+
+function listTasklineFiles() {
+  return listAllJsonFiles().filter(file => !EXCLUDED_FILES.has(file));
+}
+
+function hashRawFiles() {
+  const hashes = {};
+  listTasklineFiles().forEach(file => {
+    const content = fs.readFileSync(path.join(DATA_DIR, file));
+    hashes[file] = crypto.createHash('sha256').update(content).digest('hex');
+  });
+  return hashes;
+}
+
+function getCounts() {
+  const counts = {};
+  listTasklineFiles().forEach(file => {
+    const parsed = JSON.parse(fs.readFileSync(path.join(DATA_DIR, file), 'utf8'));
+    const tasklines = Array.isArray(parsed) ? parsed.length : 0;
+    const steps = Array.isArray(parsed)
+      ? parsed.reduce((total, taskline) => {
+          const stepCount = Array.isArray(taskline.steps) ? taskline.steps.length : 0;
+          return total + stepCount;
+        }, 0)
+      : 0;
+    counts[file] = { tasklines, steps };
+  });
+  return counts;
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function backupFiles(backupDir) {
+  fs.mkdirSync(backupDir, { recursive: true });
+  listAllJsonFiles().forEach(file => {
+    fs.copyFileSync(path.join(DATA_DIR, file), path.join(backupDir, file));
+  });
+}
+
+function restoreFiles(backupDir) {
+  listAllJsonFiles().forEach(file => {
+    fs.rmSync(path.join(DATA_DIR, file));
+  });
+  fs.readdirSync(backupDir).forEach(file => {
+    if (file.endsWith('.json')) {
+      fs.copyFileSync(path.join(backupDir, file), path.join(DATA_DIR, file));
+    }
+  });
+}
+
+function removeFiles() {
+  listAllJsonFiles().forEach(file => {
+    fs.rmSync(path.join(DATA_DIR, file));
+  });
+}
+
+function applyPartialDeletions() {
+  const daisyPath = path.join(DATA_DIR, 'daisy_gardens.json');
+  const daisy = JSON.parse(fs.readFileSync(daisyPath, 'utf8'));
+  daisy.shift();
+  writeJson(daisyPath, daisy);
+
+  const brrrghPath = path.join(DATA_DIR, 'the_brrrgh.json');
+  const brrrgh = JSON.parse(fs.readFileSync(brrrghPath, 'utf8'));
+  brrrgh.pop();
+  writeJson(brrrghPath, brrrgh);
+
+  const ttcPath = path.join(DATA_DIR, 'toontown_central.json');
+  const ttc = JSON.parse(fs.readFileSync(ttcPath, 'utf8'));
+  if (ttc[0] && Array.isArray(ttc[0].steps)) {
+    ttc[0].steps.pop();
+  }
+  writeJson(ttcPath, ttc);
+}
+
+function appendResults(lines) {
+  const timestamp = new Date().toISOString();
+  const newRun = [
+    '',
+    `Test Run: ${timestamp}`,
+    ...lines,
+    '',
+  ].join('\n');
+
+  // Keep only the last test run to prevent unbounded growth
+  let existingContent = '';
+  if (fs.existsSync(RESULTS_PATH)) {
+    const fullContent = fs.readFileSync(RESULTS_PATH, 'utf8');
+    const runs = fullContent.split(/(?=\nTest Run: )/);
+    // Keep the most recent run (last element)
+    if (runs.length > 0) {
+      existingContent = runs[runs.length - 1].trimStart();
+    }
+  }
+
+  const finalContent = existingContent ? `${existingContent}\n${newRun}` : newRun;
+  fs.writeFileSync(RESULTS_PATH, finalContent);
+}
+
+function main() {
+  const args = new Set(process.argv.slice(2));
+  const useExistingBaseline = args.has('--baseline-existing');
+  const backupDir = path.join(__dirname, 'test_backups', `run-${Date.now()}`);
+  const results = [];
+
+  let baseHashes, baseCounts;
+
+  if (useExistingBaseline) {
+    results.push('Steps');
+    results.push('0) Using existing files as baseline (skip initial refresh)');
+    baseHashes = hashRawFiles();
+    baseCounts = getCounts();
+    results.push(`- Captured baseline from existing files`);
+  } else {
+    results.push('Steps');
+    results.push('1) Run refresh and capture hashes');
+    run(`node scripts/tasklines/update_tasklines.js --refresh --report-path ${REPORT_PATH}`);
+    baseHashes = hashRawFiles();
+    baseCounts = getCounts();
+  }
+
+  if (useExistingBaseline) {
+    results.push('1) Refresh from wiki and compare to existing baseline');
+  } else {
+    results.push('1b) Re-run refresh and confirm deterministic output');
+  }
+  run(`node scripts/tasklines/update_tasklines.js --refresh --report-path ${REPORT_PATH}`);
+  const repeatHashes = hashRawFiles();
+  const repeatMatch = JSON.stringify(baseHashes) === JSON.stringify(repeatHashes);
+  if (useExistingBaseline) {
+    results.push(`- Local files match wiki: ${repeatMatch ? 'PASS' : 'FAIL (wiki has updates)'}`);
+  } else {
+    results.push(`- Repeat refresh hash match: ${repeatMatch ? 'PASS' : 'FAIL'}`);
+  }
+
+  results.push('2) Backup JSON files and regenerate from empty folder');
+  backupFiles(backupDir);
+  removeFiles();
+  run(`node scripts/tasklines/update_tasklines.js --refresh --report-path ${REPORT_PATH}`);
+  const regenCounts = getCounts();
+  const regenMatch = JSON.stringify(baseCounts) === JSON.stringify(regenCounts);
+  results.push(`- Regeneration count match: ${regenMatch ? 'PASS' : 'FAIL'}`);
+  if (!regenMatch) {
+    const mismatches = Object.keys(baseCounts).filter(file => {
+      const base = baseCounts[file];
+      const regen = regenCounts[file];
+      return !regen || base.tasklines !== regen.tasklines || base.steps !== regen.steps;
+    });
+    results.push(`- Regeneration count mismatches: ${mismatches.join(', ') || 'none'}`);
+  }
+
+  results.push('3) Apply partial deletions and rerun refresh');
+  applyPartialDeletions();
+  run(`node scripts/tasklines/update_tasklines.js --refresh --report-path ${REPORT_PATH}`);
+  const postDeletionCounts = getCounts();
+  const restoreMatch = JSON.stringify(baseCounts) === JSON.stringify(postDeletionCounts);
+  results.push(`- Partial deletion recovery (counts): ${restoreMatch ? 'PASS' : 'FAIL'}`);
+  if (!restoreMatch) {
+    const mismatches = Object.keys(baseCounts).filter(file => {
+      const base = baseCounts[file];
+      const current = postDeletionCounts[file];
+      return !current || base.tasklines !== current.tasklines || base.steps !== current.steps;
+    });
+    results.push(`- Recovery count mismatches: ${mismatches.join(', ') || 'none'}`);
+  }
+
+  results.push('4) Restore backup to reset state');
+  restoreFiles(backupDir);
+  results.push('- Restore completed');
+
+  results.push('5) Clean up test backup directory');
+  fs.rmSync(backupDir, { recursive: true, force: true });
+  results.push('- Cleanup completed');
+
+  appendResults(results);
+}
+
+main();

--- a/scripts/tasklines/update_tasklines.js
+++ b/scripts/tasklines/update_tasklines.js
@@ -1,0 +1,385 @@
+const fs = require('fs');
+const path = require('path');
+
+const {
+  OUTPUT_DIR,
+  METADATA_PATH,
+  PLAYGROUND_CONFIGS,
+  SPECIAL_CONFIGS,
+  COG_DISGUISE_PAGES,
+  CASHBOT_DISGUISE_CONFIGS,
+} = require('./lib/config');
+const { fetchCategoryMembers, fetchPageContent } = require('./lib/wiki');
+const {
+  slugify,
+  extractSection,
+  splitSubsections,
+  parseToonTaskSteps,
+  parseCogDisguiseSteps,
+  normalizeTasklineName,
+  buildWikiUrl,
+} = require('./lib/parser');
+const { diffTasklines, getDiffSummary, writeReport } = require('./lib/report');
+const { writeMetadata } = require('./lib/metadata');
+
+function loadExisting(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Failed to read ${filePath}: ${error.message}`);
+  }
+}
+
+function getTasklineKey(taskline) {
+  return `${taskline.wikiUrl || 'no-wiki'}::${taskline.id}`;
+}
+
+function orderByExisting(items, existingItems) {
+  const indexMap = new Map(
+    existingItems.map((item, index) => [getTasklineKey(item), index])
+  );
+  return [...items].sort((a, b) => {
+    const aKey = getTasklineKey(a);
+    const bKey = getTasklineKey(b);
+    const aIndex = indexMap.has(aKey) ? indexMap.get(aKey) : Number.POSITIVE_INFINITY;
+    const bIndex = indexMap.has(bKey) ? indexMap.get(bKey) : Number.POSITIVE_INFINITY;
+    if (aIndex !== bIndex) {
+      return aIndex - bIndex;
+    }
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function mergeWithExisting(taskline, existing, { preferExisting }) {
+  if (!existing) {
+    return taskline;
+  }
+  if (preferExisting) {
+    return existing;
+  }
+  const existingSteps = new Map(existing.steps.map(step => [step.order, step]));
+  const mergedSteps = taskline.steps.map(step => {
+    const existingStep = existingSteps.get(step.order);
+    if (!existingStep) {
+      return step;
+    }
+    return {
+      ...step,
+      npc: step.npc ?? existingStep.npc,
+      building: step.building ?? existingStep.building,
+      location: step.location ?? existingStep.location,
+      reward: step.reward ?? existingStep.reward,
+    };
+  });
+
+  return {
+    ...taskline,
+    prerequisites: taskline.prerequisites ?? existing.prerequisites,
+    steps: mergedSteps,
+  };
+}
+
+async function writeTasklines(fileName, tasklines, { preferExisting }) {
+  const filePath = path.join(OUTPUT_DIR, fileName);
+  const existing = loadExisting(filePath);
+  const existingMap = new Map(existing.map(item => [getTasklineKey(item), item]));
+  const merged = tasklines.map(item =>
+    mergeWithExisting(item, existingMap.get(getTasklineKey(item)), { preferExisting })
+  );
+  const ordered = orderByExisting(merged, existing);
+  const nextContent = `${JSON.stringify(ordered, null, 2)}\n`;
+  const diff = diffTasklines(existing, ordered, getTasklineKey);
+
+  if (preferExisting && fs.existsSync(filePath)) {
+    const existingContent = fs.readFileSync(filePath, 'utf8');
+    if (existingContent.trim() === nextContent.trim()) {
+      return { filePath, count: ordered.length, skipped: true, diff };
+    }
+  }
+
+  fs.writeFileSync(filePath, nextContent);
+  return { filePath, count: ordered.length, skipped: false, diff };
+}
+
+/**
+ * @param {any} config
+ * @param {Map<string, any>} existingByWikiUrl
+ * @param {Array<{title: string, reason: string}>} failures
+ * @returns {Promise<Array<any>>}
+ */
+async function buildToonTasksFromCategory(config, existingByWikiUrl, failures) {
+  const members = await fetchCategoryMembers(config.category);
+  const tasks = [];
+  for (const member of members) {
+    if (!member.title.includes('/')) {
+      continue;
+    }
+    const titlePart = member.title.split('/')[1];
+    const wikiUrl = buildWikiUrl(member.title);
+    let page;
+    try {
+      page = await fetchPageContent(member.title);
+    } catch (error) {
+      failures.push({ title: member.title, reason: `Fetch failed: ${error.message}` });
+      if (existingByWikiUrl.has(wikiUrl)) {
+        tasks.push(existingByWikiUrl.get(wikiUrl));
+      }
+      continue;
+    }
+    const section = extractSection(page.wikitext);
+    if (!section) {
+      failures.push({ title: member.title, reason: 'Missing ToonTask section' });
+      if (existingByWikiUrl.has(wikiUrl)) {
+        tasks.push(existingByWikiUrl.get(wikiUrl));
+      }
+      continue;
+    }
+
+    const subsections = splitSubsections(section);
+    for (const { subsectionName, content } of subsections) {
+      let steps;
+      try {
+        steps = parseToonTaskSteps(content);
+      } catch (error) {
+        failures.push({ title: member.title, reason: `Parse failed: ${error.message}` });
+        if (existingByWikiUrl.has(wikiUrl)) {
+          tasks.push(existingByWikiUrl.get(wikiUrl));
+        }
+        continue;
+      }
+      if (!steps.length) {
+        failures.push({ title: member.title, reason: 'No steps parsed' });
+        if (existingByWikiUrl.has(wikiUrl)) {
+          tasks.push(existingByWikiUrl.get(wikiUrl));
+        }
+        continue;
+      }
+
+      let name = normalizeTasklineName(titlePart);
+      if (/Cashbot Cog Disguise/i.test(titlePart)) {
+        const partMatch = titlePart.match(/\(([^)]+)\)$/);
+        if (partMatch) {
+          name = partMatch[1].replace(/_/g, ' ').trim();
+        }
+      }
+
+      if (subsectionName) {
+        name = `${name} (${subsectionName})`;
+      }
+
+      tasks.push({
+        id: `${slugify(config.playground)}_${slugify(name)}`,
+        name,
+        playground: config.playground,
+        category: config.taskCategory,
+        steps,
+        wikiUrl,
+        lastUpdated: page.timestamp || undefined,
+      });
+    }
+  }
+  return tasks;
+}
+
+/**
+ * @param {any} pageConfig
+ * @param {Array<{title: string, reason: string}>} failures
+ * @returns {Promise<Array<any>>}
+ */
+async function buildCogDisguiseFromPage(pageConfig, failures) {
+  let page;
+  try {
+    page = await fetchPageContent(pageConfig.title);
+  } catch (error) {
+    failures.push({ title: pageConfig.title, reason: `Fetch failed: ${error.message}` });
+    return [];
+  }
+  const section = extractSection(page.wikitext);
+  if (!section) {
+    failures.push({ title: pageConfig.title, reason: 'Missing ToonTasks section' });
+    return [];
+  }
+  let tasklines;
+  try {
+    tasklines = parseCogDisguiseSteps(section);
+  } catch (error) {
+    failures.push({ title: pageConfig.title, reason: `Parse failed: ${error.message}` });
+    return [];
+  }
+  return tasklines.map(taskline => ({
+    id: `${slugify(pageConfig.playground)}_${slugify(taskline.name)}`,
+    name: taskline.name,
+    playground: pageConfig.playground,
+    category: 'cog_disguise',
+    steps: taskline.steps,
+    wikiUrl: buildWikiUrl(pageConfig.title),
+    lastUpdated: page.timestamp || undefined,
+  }));
+}
+
+/**
+ * @param {any} categoryConfig
+ * @param {Map<string, any>} existingByWikiUrl
+ * @param {Array<{title: string, reason: string}>} failures
+ * @returns {Promise<Array<any>>}
+ */
+async function buildCashbotDisguiseFromCategory(categoryConfig, existingByWikiUrl, failures) {
+  const members = await fetchCategoryMembers(categoryConfig.category);
+  const tasks = [];
+  for (const member of members) {
+    if (!member.title.includes(categoryConfig.titleSubstring)) {
+      continue;
+    }
+    const titlePart = member.title.split('/')[1] || member.title;
+    const wikiUrl = buildWikiUrl(member.title);
+    let page;
+    try {
+      page = await fetchPageContent(member.title);
+    } catch (error) {
+      failures.push({ title: member.title, reason: `Fetch failed: ${error.message}` });
+      if (existingByWikiUrl.has(wikiUrl)) {
+        tasks.push(existingByWikiUrl.get(wikiUrl));
+      }
+      continue;
+    }
+    const section = extractSection(page.wikitext);
+    if (!section) {
+      failures.push({ title: member.title, reason: 'Missing ToonTask section' });
+      if (existingByWikiUrl.has(wikiUrl)) {
+        tasks.push(existingByWikiUrl.get(wikiUrl));
+      }
+      continue;
+    }
+
+    const subsections = splitSubsections(section);
+    for (const { subsectionName, content } of subsections) {
+      let steps;
+      try {
+        steps = parseToonTaskSteps(content);
+      } catch (error) {
+        failures.push({ title: member.title, reason: `Parse failed: ${error.message}` });
+        if (existingByWikiUrl.has(wikiUrl)) {
+          tasks.push(existingByWikiUrl.get(wikiUrl));
+        }
+        continue;
+      }
+      if (!steps.length) {
+        failures.push({ title: member.title, reason: 'No steps parsed' });
+        if (existingByWikiUrl.has(wikiUrl)) {
+          tasks.push(existingByWikiUrl.get(wikiUrl));
+        }
+        continue;
+      }
+
+      const match = titlePart.match(/\(([^)]+)\)$/);
+      let name = match ? match[1].replace(/_/g, ' ').trim() : normalizeTasklineName(titlePart);
+
+      if (subsectionName) {
+        name = `${name} (${subsectionName})`;
+      }
+
+      tasks.push({
+        id: `${slugify(categoryConfig.playground)}_${slugify(name)}`,
+        name,
+        playground: categoryConfig.playground,
+        category: 'cog_disguise',
+        steps,
+        wikiUrl,
+        lastUpdated: page.timestamp || undefined,
+      });
+    }
+  }
+  return tasks;
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  const preferExisting = !args.has('--refresh');
+  const reportPathArgIndex = process.argv.indexOf('--report-path');
+  const reportPath =
+    reportPathArgIndex !== -1 ? process.argv[reportPathArgIndex + 1] : null;
+
+  const outputs = [];
+  const failures = [];
+  for (const config of PLAYGROUND_CONFIGS) {
+    const existing = loadExisting(path.join(OUTPUT_DIR, config.file));
+    const existingByWikiUrl = new Map(existing.map(item => [item.wikiUrl, item]));
+    let tasklines;
+    try {
+      tasklines = await buildToonTasksFromCategory(config, existingByWikiUrl, failures);
+    } catch (error) {
+      failures.push({ title: config.category, reason: error.message });
+      tasklines = existing;
+    }
+    outputs.push(await writeTasklines(config.file, tasklines, { preferExisting }));
+  }
+
+  for (const config of SPECIAL_CONFIGS) {
+    const existing = loadExisting(path.join(OUTPUT_DIR, config.file));
+    const existingByWikiUrl = new Map(existing.map(item => [item.wikiUrl, item]));
+    let tasklines;
+    try {
+      tasklines = await buildToonTasksFromCategory(config, existingByWikiUrl, failures);
+    } catch (error) {
+      failures.push({ title: config.category, reason: error.message });
+      tasklines = existing;
+    }
+    outputs.push(await writeTasklines(config.file, tasklines, { preferExisting }));
+  }
+
+  {
+    const existing = loadExisting(path.join(OUTPUT_DIR, CASHBOT_DISGUISE_CONFIGS.file));
+    const existingByWikiUrl = new Map(existing.map(item => [item.wikiUrl, item]));
+    let cashbotTasklines;
+    try {
+      cashbotTasklines = await buildCashbotDisguiseFromCategory(
+        {
+          ...CASHBOT_DISGUISE_CONFIGS,
+          category: "Donald's Dreamland ToonTasks",
+        },
+        existingByWikiUrl,
+        failures
+      );
+    } catch (error) {
+      failures.push({ title: CASHBOT_DISGUISE_CONFIGS.file, reason: error.message });
+      cashbotTasklines = existing;
+    }
+    outputs.push(
+      await writeTasklines(CASHBOT_DISGUISE_CONFIGS.file, cashbotTasklines, {
+        preferExisting,
+      })
+    );
+  }
+
+  for (const pageConfig of COG_DISGUISE_PAGES) {
+    const existing = loadExisting(path.join(OUTPUT_DIR, pageConfig.file));
+    let tasklines;
+    try {
+      tasklines = await buildCogDisguiseFromPage(pageConfig, failures);
+      if (tasklines.length === 0) {
+        failures.push({ title: pageConfig.title, reason: 'No tasklines parsed' });
+        tasklines = existing;
+      }
+    } catch (error) {
+      failures.push({ title: pageConfig.title, reason: error.message });
+      tasklines = existing;
+    }
+    outputs.push(await writeTasklines(pageConfig.file, tasklines, { preferExisting }));
+  }
+
+  outputs.forEach(output => {
+    const prefix = output.skipped ? 'Unchanged' : 'Wrote';
+    console.log(`${prefix} ${output.count} tasklines -> ${output.filePath}`);
+  });
+
+  writeReport(reportPath, outputs, failures);
+  writeMetadata(METADATA_PATH, outputs, failures, getDiffSummary);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
- This PR introduces an automated system for keeping taskline data synchronized with the https://toontownrewritten.wiki
This was used to create the task.json files in #122 

### Files:
  - Wiki scraper (scripts/tasklines/update_tasklines.js) - Fetches and parses taskline data from wiki API
  - GitHub Actions workflow (.github/workflows/taskline-update.yml) - Weekly automated updates via PR
  - Comprehensive test suite (scripts/tasklines/run_update_tests.js) - Validates deterministic behavior and data integrity of updates

### How It Works
#### Automated Workflow:
  1. Runs every Monday at 9am (manual trigger available)
  2. Fetches latest taskline data from wiki
  3. Captures lastUpdated timestamp from wiki revisions
  4. Creates/updates PR on automation/taskline-update branch when changes are detected (can also be manual trigger)
  5. PR body contains detailed diff report
  6. Maintainers review and merge when ready


### Local Testing
  Update tasklines from wiki:
  - Preserve existing files (only add missing)
  `node scripts/tasklines/update_tasklines.js`

  - Force full refresh from wiki
  `node scripts/tasklines/update_tasklines.js --refresh`

  - Generate diff report
  `node scripts/tasklines/update_tasklines.js --refresh --report-path .github/taskline-update-report.md`

  Run tests:
  - Standard test suite (verifies script behavior)
  `node scripts/tasklines/run_update_tests.js`

  - Check if local files match wiki (verifies data freshness)
  `node scripts/tasklines/run_update_tests.js --baseline-existing`

  - Expected Test result in : `UPDATE_TASKLINES_TEST_RESULTS.md`
    - All tests passing:
    - Repeat refresh hash match: PASS
    - Regeneration count match: PASS
    - Partial deletion recovery: PASS
    - Cleanup completed
