### PR TITLE
fix: resolve taskline matching failures for laff boost, ToonTask capa…

### DIFF
--- a/packages/webapp/app/utils/normalizationPatterns.ts
+++ b/packages/webapp/app/utils/normalizationPatterns.ts
@@ -62,6 +62,11 @@ const OBJECTIVE_NORMALIZATIONS: Array<{
     replacement: ' and ',
     description: 'Normalize ampersand to "and"',
   },
+  {
+    pattern: /^go to\s+/g,
+    replacement: 'visit ',
+    description: 'Normalize "go to X" to "visit X" (wiki/game verb mismatch)',
+  },
 ];
 
 /**

--- a/packages/webapp/app/utils/tasklineFilterPipeline.ts
+++ b/packages/webapp/app/utils/tasklineFilterPipeline.ts
@@ -196,9 +196,17 @@ function filterByFirstStep(
   }
 
   const isFirstStep = !fromNpc || fromNpc === "";
-  return filterWithFallback(candidates, (c) =>
-    isFirstStep ? c.step.order === 1 : c.step.order !== 1
-  );
+  return filterWithFallback(candidates, (c) => {
+    if (!isFirstStep) {
+      return c.step.order !== 1;
+    }
+    if (c.step.order === 1) return true;
+
+    // Exception: If the objective text matches exactly (normalized), allow it even if not step 1
+    // This handles cases where 'from' data is missing but the objective uniquely identifies a later step
+    const candidateObj = normalizeTaskText(c.objective.text);
+    return candidateObj === normalizedObjective;
+  });
 }
 
 /** Filter with fallback - returns matches if any, otherwise all candidates */
@@ -251,8 +259,20 @@ function filterByReward(
   if (normalizedTaskReward) {
     const matched = candidates.filter((c) => {
       const candidateReward = normalizeTaskText(getCandidateReward(c));
-      return candidateReward.includes(normalizedTaskReward) ||
-             normalizedTaskReward.includes(candidateReward);
+      if (
+        candidateReward.includes(normalizedTaskReward) ||
+        normalizedTaskReward.includes(candidateReward)
+      ) {
+        return true;
+      }
+      // "Carry X ToonTasks" → "Increased ToonTask capacity" fuzzy match
+      if (
+        normalizedTaskReward.includes("toontask") &&
+        candidateReward.includes("toontask")
+      ) {
+        return true;
+      }
+      return false;
     });
     return matched.length > 0 ? matched : candidates;
   }

--- a/packages/webapp/app/utils/tasklineMatching.ts
+++ b/packages/webapp/app/utils/tasklineMatching.ts
@@ -66,29 +66,34 @@ function categorizeTask(task: Task): TaskCategory {
 }
 
 function isGenericHqOfficerTask(task: Task): boolean {
-  // Gag training tasks go to HQ Officer but are documented tasklines, not random
-  const reward = task.reward?.toLowerCase() ?? "";
-  if (reward.includes("gag training") || reward.includes("gag track training")) {
-    return false;
-  }
+  // "Call Clarabelle" tasks are always random procedural tasks
+  const objective = task.objective?.text?.toLowerCase() ?? "";
+  if (objective.includes("clarabelle")) return true;
 
+  // Check structural HQ officer profile
+  if (!isGenericHqOfficerProfile(task)) return false;
+
+  // Exclude rewards that correspond to documented tasklines
+  const reward = task.reward?.toLowerCase() ?? "";
+  if (reward.includes("laff boost")) return false;
+  if (reward.includes("toontask") || reward.includes("toon task")) return false;
+  if (reward.includes("gag training")) return false;
+  if (reward.includes("teleport access")) return false;
+
+  return true;
+}
+
+/** Structural check: task goes to generic HQ Officer at "Any" location with no/HQ from */
+function isGenericHqOfficerProfile(task: Task): boolean {
   const toNpc = task.to?.name?.toLowerCase().trim() ?? "";
   if (!toNpc.includes("hq officer") && toNpc !== "hq") return false;
-
   const zone = task.to?.zone?.toLowerCase() ?? "";
   const neighborhood = task.to?.neighborhood?.toLowerCase() ?? "";
-  const hasGenericLocation = zone.includes("any") || neighborhood.includes("any");
-  if (!hasGenericLocation) return false;
-
+  if (!zone.includes("any") && !neighborhood.includes("any")) return false;
   const fromNpc = task.from?.name?.toLowerCase().trim() ?? "";
-  const fromEmpty = !fromNpc;
-  const fromIsHqRelated =
-    fromNpc.includes("hq officer") ||
-    fromNpc === "hq" ||
-    fromNpc.startsWith("hq ");
-
-  return fromEmpty || fromIsHqRelated;
+  return !fromNpc || fromNpc.includes("hq officer") || fromNpc === "hq" || fromNpc.startsWith("hq ");
 }
+
 
 function extractLocation(task: Task): string | null {
   const where = task.objective.where?.trim().toLowerCase();
@@ -278,12 +283,14 @@ export function findTasklineMatchWithToonDataDetailed(
 
   // Handle no matches
   if (matchCandidates.length === 0) {
+    // Tasks that passed isGenericHqOfficerTask (e.g., laff boost) but still failed
+    // to match any documented step are reclassified as random
+    const unmatchedReason =
+      isGenericHqOfficerProfile(task) ? "random_reward"
+        : candidates.length ? "no_match" : "no_candidates";
     return {
       match: null,
-      debug: {
-        category,
-        unmatchedReason: candidates.length ? "no_match" : "no_candidates",
-      },
+      debug: { category: unmatchedReason === "random_reward" ? "random_reward" : category, unmatchedReason },
     };
   }
 

--- a/packages/webapp/app/utils/tasklineStepSignals.ts
+++ b/packages/webapp/app/utils/tasklineStepSignals.ts
@@ -47,6 +47,8 @@ function hasNpcConflict(task: Task, stepObjective: string): boolean {
   const taskNpc = task.to?.name?.trim();
   if (!taskNpc) return false;
   const normalizedStep = normalizeTaskText(stepObjective);
+  // "Go to [location]" objectives are navigation, not NPC delivery — skip conflict check
+  if (normalizedStep.startsWith("go to ")) return false;
   const toNpcMatch = normalizedStep.match(/\bto\s+([a-z]+(?:\s+[a-z]+)*)\s*$/i);
   if (!toNpcMatch) return false;
   const stepNpc = toNpcMatch[1].toLowerCase().trim();


### PR DESCRIPTION
###  Problem

#### Three categories of tasks were failing to match their documented wiki tasklines:

  1. `Visit Sellbot Task Force Hideout` (Trainee Badge) — The wiki uses "Go to" while the game API returns "Visit". Additionally, the NPC
  conflict checker's greedy regex was matching the location name "Sellbot Task Force Hideout" as if it were an NPC name, rejecting valid  candidates.
  2. `Recover a Sprocket from Back Stabbers` (2 point Laff boost) — The isGenericHqOfficerTask function was too aggressive with reward
  exclusions, causing this task to be categorized as random when it actually corresponds to a documented Daisy Gardens laff boost taskline. 
  3. `Defeat 2 two+ story Cog Buildings` (Carry 3 ToonTasks) — The reward text "Carry 3 ToonTasks" didn't match the wiki's "Increased
  ToonTask capacity", and the first-step filter was rejecting candidates because the task had empty from data (no originating NPC).

### Screenshots:

<img width="1138" height="1348" alt="image" src="https://github.com/user-attachments/assets/5b45a5eb-6d8b-4b01-9a8e-9d9b619e395e" />

<img width="1338" height="1078" alt="image" src="https://github.com/user-attachments/assets/b3b7057f-dc27-48fe-a4af-4301c22f43bb" />

<img width="1129" height="1194" alt="image" src="https://github.com/user-attachments/assets/0e980cb2-bc34-455e-a476-d15ef64eef58" />



### Changes:
  - normalizationPatterns.ts (+5): Add "go to" → "visit" objective normalization
  - tasklineStepSignals.ts (+2): Skip NPC conflict check for "Go to" objectives (they're navigation, not NPC delivery)
  - tasklineFilterPipeline.ts (+30/-5): Allow non-step-1 candidates when objective text matches exactly; add ToonTask fuzzy reward
  matching
  - tasklineMatching.ts (+45/-19): Expand` isGenericHqOfficerTask` reward exclusions; add Clarabelle objective check to prevent false positives; add fallback reclassification via `isGenericHqOfficerProfile`